### PR TITLE
Upgrade to Electron 2.0.0 and address security issues

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,21 @@
 {
   "electron": {
     "appName": "OpenSphere",
-    "releaseUrl": "https://github.com/ngageoint/opensphere-electron/releases"
+    "releaseUrl": "https://github.com/ngageoint/opensphere-electron/releases",
+    "webPreferences": {
+      //
+      // Enable web security to enforce CORS and prevent execution of insecure code.
+      //
+      // https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content
+      //
+      "webSecurity": true,
+      //
+      // Disable node integration to prevent XSS attacks from having access to it.
+      // If needed, introduce minimal interfaces through a preload script.
+      //
+      // https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content
+      //
+      "nodeIntegration": false
+    }
   }
 }

--- a/docs/app_configuration/default.json
+++ b/docs/app_configuration/default.json
@@ -1,6 +1,10 @@
 {
   "electron": {
     "appName": "My OpenSphere App",
-    "releaseUrl": "https://myopensphereapp.io/releases/"
+    "releaseUrl": "https://myopensphereapp.io/releases/",
+    "webPreferences": {
+      "nodeIntegration": true,
+      "webSecurity": false
+    }
   }
 }

--- a/docs/app_configuration/index.rst
+++ b/docs/app_configuration/index.rst
@@ -30,4 +30,13 @@ The ``productName`` key will be used in creating the installer file names, and t
 
 The ``electron.appName`` key will be used to replace the value returned by ``app.getName()`` in Electron, and the ``electron.releaseUrl`` will be launched if users wish to update a portable Windows build. Non-portable (installed) applications can be updated automatically by configuring Electron Builder's `auto update`_.
 
+The ``webPreferences`` key modifies the object passed to the main `BrowserWindow`_, changing how the window is created/configured. In the example, the following defaults are changed:
+
+* ``webSecurity`` is disabled to allow access to sites that do not support CORS.
+* ``nodeIntegration`` is enabled to provide a full Node environment to the application.
+
+Both of these are discouraged by the `Electron security tutorial`_, so be sure you fully understand the implications before changing settings like these.
+
 .. _auto update: https://www.electron.build/auto-update
+.. _BrowserWindow: https://electronjs.org/docs/api/browser-window
+.. _Electron security tutorial: https://electronjs.org/docs/tutorial/security

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "open": "^0.0.5"
   },
   "devDependencies": {
-    "electron": "1.8.4",
-    "electron-builder": "20.8.1",
+    "electron": "2.0.0",
+    "electron-builder": "20.13.1",
     "eslint": "^4.18.1",
     "eslint-config-google": "^0.9.1"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -177,6 +177,25 @@ app.on('activate', function() {
   }
 });
 
+app.on('web-contents-created', function(event, contents) {
+  contents.on('will-attach-webview', function(event, webPreferences, params) {
+    // Strip away preload scripts because they always have Node integration enabled
+    delete webPreferences.preload;
+    delete webPreferences.preloadURL;
+
+    // Disable Node.js integration
+    webPreferences.nodeIntegration = false;
+
+    // Enable web security
+    webPreferences.webSecurity = true;
+
+    // Verify URL being loaded is local to the app
+    if (!params.src.startsWith('file://' + osPath)) {
+      event.preventDefault();
+    }
+  });
+});
+
 /**
  * Handle update download progress event.
  * @param {DownloadProgress} info The download progress info.

--- a/src/main.js
+++ b/src/main.js
@@ -59,20 +59,30 @@ const loadConfig = function() {
  * Create the main application window.
  */
 const createMainWindow = function() {
+  // Default web preferences for the main browser window.
+  const webPreferences = {
+    // Don't throttle animations/timers when backgrounded.
+    backgroundThrottling: false,
+    // Use native window.open so external windows can access their parent.
+    nativeWindowOpen: true,
+    // Run the preload script before other scripts on the page.
+    preload: 'preload.js'
+  };
+
+  // Load additional preferences from config.
+  if (config.has('electron.webPreferences')) {
+    const configWebPreferences = config.get('electron.webPreferences');
+    if (configWebPreferences) {
+      Object.assign(webPreferences, configWebPreferences);
+    }
+  }
+
   // Create the browser window.
   mainWindow = new BrowserWindow({
     width: 1600,
     height: 900,
-    webPreferences: {
-      // Don't throttle animations/timers when backgrounded.
-      backgroundThrottling: false,
-      // Use native window.open so external windows can access their parent.
-      nativeWindowOpen: true,
-      // Disable CORS.
-      webSecurity: false
-    }
+    webPreferences: webPreferences
   });
-
 
   // Delete X-Frame-Options header from XHR responses to avoid preventing URL's from displaying in an iframe.
   mainWindow.webContents.session.webRequest.onHeadersReceived({}, function(details, callback) {

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,0 +1,2 @@
+// allow the file:// protocol to be used by the fetch API
+require('electron').webFrame.registerURLSchemeAsPrivileged('file');


### PR DESCRIPTION
No breaking changes, but Electron 2.0.0 started warning about potential security issues so I made some adjustments to resolve a few of those.

I did not address the Content Security Policy warning because it does not allow use of `eval`, which is being used in `opensphere-asm`'s WebAssembly code.

**WebSecurity is now enabled by default.**
https://electronjs.org/docs/tutorial/security#5-do-not-disable-websecurity

This can be disabled via config for builds that need to access servers lacking CORS config, but enabling it is the better default for security reasons.

**Node integration is now disabled in the main BrowserWindow.**
https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content

OpenSphere loads remote content from both config- and user-defined services, which makes Node integration dangerous in the main browser window.

Code that needs to use Node should either do so in a different process (BrowserWindow, WebView, Worker, etc) that is protected from remote content, or perform Node tasks in the `preload.js` script and expose a more limited API to the main process. As a last resort, `nodeIntegration` can be enabled in the Electron config, but this should _not_ be done in the default config (`config/default.json`).