### PR TITLE
Upgrade Electron to 4.1.0.

### DIFF
--- a/app/src/appmenu.js
+++ b/app/src/appmenu.js
@@ -1,5 +1,4 @@
 const {app, BrowserWindow} = require('electron');
-const isDev = require('electron-is-dev');
 
 const editMenu = {
   label: 'Edit',
@@ -63,7 +62,7 @@ const viewMenu = {
   }]
 };
 
-if (isDev) {
+if (!app.isPackaged) {
   viewMenu.submenu.push({
     label: 'Toggle Developer Tools',
     accelerator: (function() {

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -10,11 +10,10 @@ const log = require('electron-log');
 log.transports.file.level = 'debug';
 
 // Determine which environment we're running in.
-const isDev = require('electron-is-dev');
-const isDebug = isDev && process.argv.includes('--debug');
+const isDebug = !app.isPackaged && process.argv.includes('--debug');
 
-if (isDev) {
-  process.env.ELECTRON_IS_DEV = isDev;
+if (!app.isPackaged) {
+  process.env.ELECTRON_IS_DEV = !app.isPackaged;
 
   // this allows scripts to add this to module.paths if they want to pick up
   // native deps built for electron out of opensphere-electron/app/node_modules
@@ -28,12 +27,12 @@ if (isDev) {
 const config = require('config');
 
 // Determine the location of OpenSphere.
-const osPath = isDev ?
+const osPath = !app.isPackaged ?
     path.resolve('..', 'opensphere') :
     path.join(process.resourcesPath, 'app.asar', 'opensphere');
 
 // Determine the location of OpenSphere's index.html.
-const osIndexPath = isDebug || !isDev ?
+const osIndexPath = isDebug || !!app.isPackaged ?
     path.join(osPath, 'index.html') :
     path.join(osPath, 'dist', 'opensphere', 'index.html');
 
@@ -161,7 +160,7 @@ app.on('ready', function() {
   // Launch OpenSphere.
   createMainWindow();
 
-  if (!isDev) {
+  if (!!app.isPackaged) {
     // Allow opening Dev Tools via shortcut.
     const shortcut = process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I';
     globalShortcut.register(shortcut, function() {

--- a/package.json
+++ b/package.json
@@ -23,15 +23,14 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "config": "^1.30.0",
-    "electron-is-dev": "^0.3.0",
-    "electron-log": "^2.2.14",
-    "electron-updater": "^3.0.3",
+    "config": "^3.0.1",
+    "electron-log": "^3.0.1",
+    "electron-updater": "^4.0.6",
     "open": "^0.0.5"
   },
   "devDependencies": {
-    "electron": "2.0.7",
-    "electron-builder": "20.27.1",
+    "electron": "4.1.0",
+    "electron-builder": "20.39.0",
     "eslint": "^4.18.1",
     "eslint-config-google": "^0.9.1"
   }


### PR DESCRIPTION
Replaces electron-is-dev with app.isPackaged API.