### PR TITLE
feat(security): Disable Node integration and expose a minimal API.

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -28,14 +28,25 @@ if (isDev) {
 const config = require('config');
 
 // Determine the location of OpenSphere.
-const osPath = isDev ?
-    path.resolve('..', 'opensphere') :
-    path.join(process.resourcesPath, 'app.asar', 'opensphere');
+let osPath;
+if (isDev) {
+  // Development (command line) path
+  osPath = path.resolve('..', 'opensphere');
+
+  if (!isDebug) {
+    // Compiled app
+    osPath = path.resolve(osPath, 'dist', 'opensphere');
+  }
+} else {
+  // Production path
+  osPath = path.join(process.resourcesPath, 'app.asar', 'opensphere');
+}
+
+// Export the path for application use.
+process.env.OPENSPHERE_PATH = osPath;
 
 // Determine the location of OpenSphere's index.html.
-const osIndexPath = isDebug || !isDev ?
-    path.join(osPath, 'index.html') :
-    path.join(osPath, 'dist', 'opensphere', 'index.html');
+const osIndexPath = path.join(osPath, 'index.html');
 
 // XHR response headers that should be discarded.
 const discardedHeaders = [

--- a/app/src/preload.js
+++ b/app/src/preload.js
@@ -1,2 +1,70 @@
+/* eslint-disable */
+
+const child_process = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const process = require('process');
+const {webFrame} = require('electron');
+
 // allow the file:// protocol to be used by the fetch API
-require('electron').webFrame.registerURLSchemeAsPrivileged('file');
+webFrame.registerURLSchemeAsPrivileged('file');
+
+/**
+ * Fork a child process.
+ * @param {string} modulePath The module to run in the child.
+ * @param {Array|undefined} args List of string arguments.
+ * @param {Object|undefined} options The process options.
+ * @return {!Object} The process.
+ */
+const forkProcess = function(modulePath, args, options) {
+  return child_process.fork(modulePath, args, options);
+};
+
+/**
+ * Get Electron environment options for use in child processes.
+ * @return {!Object}
+ */
+const getElectronEnvOptions = function() {
+  var options = {
+    env: {
+      ELECTRON_EXTRA_PATH: process.env.ELECTRON_EXTRA_PATH
+    }
+  };
+
+  if ('electron' in process.versions) {
+    options.env.ELECTRON_VERSION = process.versions.electron;
+  }
+
+  return options;
+};
+
+/**
+ * Resolve a path relative to the OpenSphere base path.
+ * @param {string} base The base path.
+ * @return {string} The resolved path.
+ */
+const resolveOpenspherePath = function(base) {
+  return path.join(process.env.OPENSPHERE_PATH, base);
+};
+
+/**
+ * Asynchronously remove a file or symbolic link.
+ * @param {string} file The file.
+ * @param {Function} callback Function to call when the unlink completes.
+ */
+const unlinkFile = function(file, callback) {
+  fs.unlink(file, callback);
+};
+
+//
+// Expose a minimal interface to the Node environment for use in OpenSphere.
+//
+// For more information, see:
+// https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content
+//
+window.ElectronExports = {
+  getElectronEnvOptions: getElectronEnvOptions,
+  forkProcess: forkProcess,
+  resolveOpenspherePath: resolveOpenspherePath,
+  unlinkFile: unlinkFile
+};

--- a/config/default.json
+++ b/config/default.json
@@ -15,15 +15,8 @@
       //
       // https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content
       //
-      // Removing nodeIntegration breaks any plugin making use of native node bindings
-      // (those crash when used in Web Workers within Electron). As a workaround, we
-      // now use node's process.fork() to launch the worker as a node child process
-      // instead, and write the worker in such a way that it can handle being run
-      // in that manner in addition to the typical Web Worker path on the web.
-      //
-      // This can be swapped back for security if Electron fixes the crashing issue,
-      // but code changes will still need to be made to those plugins as well.
-      "nodeIntegration": true
+      "nodeIntegration": false,
+      "nodeIntegrationInWorker": false
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: This will break any apps/plugins expecting a full Node API. Node calls must be exposed via the preload script, or nodeIntegration enabled by outside configuration.