### PR TITLE
chore(deps): Upgrade Electron to 5.0.4, other deps to latest.

### DIFF
--- a/app/src/appmenu.js
+++ b/app/src/appmenu.js
@@ -101,7 +101,7 @@ const windowMenu = {
   }]
 };
 
-let template = [editMenu, viewMenu, windowMenu];
+const template = [editMenu, viewMenu, windowMenu];
 
 if (process.platform === 'darwin') {
   const name = app.getName();
@@ -134,7 +134,7 @@ if (process.platform === 'darwin') {
     }]
   });
 
-  let windowMenu = template.find(function(item) {
+  const windowMenu = template.find(function(item) {
     return item.label === 'Window';
   });
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -169,7 +169,7 @@ const createBrowserWindow = function(webPreferences, parentWindow) {
     } else if (url.indexOf('.html') == -1 && config.has('electron.apps')) {
       // If the HTML file isn't specified in an internal URL, check if a matching app is configured.
       const apps = config.get('electron.apps');
-      for (let appName in apps) {
+      for (const appName in apps) {
         if (url.indexOf(appName) != -1) {
           // Launch the matched app.
           event.preventDefault();
@@ -266,7 +266,7 @@ app.on('ready', function() {
     // Allow opening Dev Tools via shortcut.
     const shortcut = process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I';
     globalShortcut.register(shortcut, function() {
-      let focusedWindow = BrowserWindow.getFocusedWindow();
+      const focusedWindow = BrowserWindow.getFocusedWindow();
       if (focusedWindow) {
         focusedWindow.toggleDevTools();
       }

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "open": "^6.3.0"
   },
   "devDependencies": {
-    "electron": "5.0.3",
-    "electron-builder": "20.41.0",
-    "eslint": "^4.18.1",
-    "eslint-config-google": "^0.9.1"
+    "electron": "5.0.4",
+    "electron-builder": "20.44.4",
+    "eslint": "^5.16.0",
+    "eslint-config-google": "^0.13.0"
   }
 }


### PR DESCRIPTION
Upgraded ESLint and `eslint-config-google`, and fixed lint failures due to new rules preferring `const` over `let`.