### PR TITLE
Update Electron to 8.x

### DIFF
--- a/app/src/appenv.js
+++ b/app/src/appenv.js
@@ -1,3 +1,4 @@
+// Node Modules
 const config = require('config');
 const path = require('path');
 

--- a/app/src/appenv.js
+++ b/app/src/appenv.js
@@ -1,0 +1,58 @@
+const config = require('config');
+const path = require('path');
+
+
+/**
+ * If Electron is running in a development environment.
+ * @type {boolean}
+ */
+const isDev = require('electron-is-dev');
+
+
+/**
+ * If Electron is running the debug application.
+ * @type {boolean}
+ */
+const isDebug = isDev && process.argv.includes('--debug');
+
+
+/**
+ * Base path for the Electron app.
+ * @type {string}
+ */
+const basePath = isDev ? path.resolve('..') : path.join(process.resourcesPath, 'app.asar');
+
+
+/**
+ * Location of the base application.
+ * @type {string}
+ */
+const baseApp = config.has('electron.baseApp') ? config.get('electron.baseApp') : 'opensphere';
+
+
+/**
+ * Location of preload scripts.
+ * @type {string}
+ */
+const preloadDir = path.join(__dirname, 'preload');
+
+
+/**
+ * Initialize environment variables based on the current environment.
+ * @param {string} osPath Base path to opensphere.
+ */
+const initEnvVars = (osPath) => {
+  if (isDev) {
+    process.env.ELECTRON_IS_DEV = isDev;
+
+    // This allows scripts to add this to module.paths if they want to pick up
+    // native deps built for electron out of opensphere-electron/app/node_modules
+    process.env.ELECTRON_EXTRA_PATH = module.paths[1];
+  } else {
+    // When running in production, update the location for app configuration.
+    process.env.NODE_CONFIG_DIR = path.join(process.resourcesPath, 'config');
+  }
+};
+
+
+module.exports = {baseApp, basePath, isDev, isDebug, initEnvVars, preloadDir};

--- a/app/src/appmenu.js
+++ b/app/src/appmenu.js
@@ -1,5 +1,8 @@
-const {app, BrowserWindow} = require('electron');
+// Node Modules
 const isDev = require('electron-is-dev');
+
+// Electron Modules
+const {app, BrowserWindow} = require('electron');
 
 const editMenu = {
   label: 'Edit',

--- a/app/src/appmenu.js
+++ b/app/src/appmenu.js
@@ -104,7 +104,7 @@ const windowMenu = {
 const template = [editMenu, viewMenu, windowMenu];
 
 if (process.platform === 'darwin') {
-  const name = app.getName();
+  const name = app.name;
   template.unshift({
     label: name,
     submenu: [{

--- a/app/src/apppath.js
+++ b/app/src/apppath.js
@@ -1,0 +1,73 @@
+const config = require('config');
+const path = require('path');
+const url = require('url');
+
+const appEnv = require('./appenv.js');
+
+
+/**
+ * Get the path for an application.
+ * @param {string} appName The application name.
+ * @param {string} basePath The base application path.
+ * @return {string} The application path.
+ */
+const getAppPath = (appName, basePath) => {
+  let appPath;
+
+  const configKey = `electron.apps.${appName}`;
+  const appConfig = config.has(configKey) ? config.get(configKey) : {};
+  const baseAppPath = appConfig.path || appName;
+
+  if (appEnv.isDev) {
+    // Development (command line) path
+    appPath = path.resolve(basePath, baseAppPath);
+
+    if (!appEnv.isDebug) {
+      // Compiled app
+      appPath = path.resolve(appPath, 'dist', baseAppPath);
+    }
+  } else {
+    // Production path
+    appPath = path.join(basePath, baseAppPath);
+  }
+
+  return appPath;
+};
+
+
+/**
+ * Get the URL to load an application.
+ * @param {string} appName The application name.
+ * @param {string} baseUrl The base application URL.
+ * @return {string} The application URL.
+ */
+const getAppUrl = (appName, baseUrl) => {
+  const appPath = getAppPath(appName, baseUrl);
+  return url.format({
+    pathname: path.join(appPath, 'index.html'),
+    protocol: 'file:',
+    slashes: true
+  });
+};
+
+
+/**
+ * Get the app name from a URL.
+ * @param {string} url The URL.
+ * @return {?string} The app name, or null if not found.
+ */
+const getAppFromUrl = (url) => {
+  let matchedApp = null;
+  if (config.has('electron.apps')) {
+    const apps = config.get('electron.apps');
+    for (const appName in apps) {
+      if (url.indexOf(appName) != -1 && (!matchedApp || matchedApp.length < appName.length)) {
+        matchedApp = appName;
+      }
+    }
+  }
+  return matchedApp;
+};
+
+
+module.exports = {getAppPath, getAppFromUrl, getAppUrl};

--- a/app/src/apppath.js
+++ b/app/src/apppath.js
@@ -1,7 +1,9 @@
+// Node Modules
 const config = require('config');
 const path = require('path');
 const url = require('url');
 
+// Local Modules
 const appEnv = require('./appenv.js');
 
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -1,13 +1,16 @@
-const {app, dialog, globalShortcut, protocol, shell, BrowserWindow, Menu} = require('electron');
-const {autoUpdater} = require('electron-updater');
-
+// Node Modules
 const config = require('config');
 const fs = require('fs');
 const log = require('electron-log');
+const {autoUpdater} = require('electron-updater');
 const open = require('open');
 const path = require('path');
 const slash = require('slash');
 
+// Electron Modules
+const {app, dialog, globalShortcut, protocol, shell, BrowserWindow, Menu} = require('electron');
+
+// Local Modules
 const appEnv = require('./appenv.js');
 const {getAppPath, getAppFromUrl, getAppUrl} = require('./apppath.js');
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -13,6 +13,7 @@ const {app, dialog, globalShortcut, protocol, shell, BrowserWindow, Menu} = requ
 // Local Modules
 const appEnv = require('./appenv.js');
 const {getAppPath, getAppFromUrl, getAppUrl} = require('./apppath.js');
+const {getDefaultWebPreferences} = require('./prefs.js');
 
 // Configure logger.
 log.transports.file.level = 'debug';
@@ -163,12 +164,7 @@ const createAppWindow = (appName, url, parentWindow) => {
  */
 const createMainWindow = () => {
   // Default web preferences for the main browser window.
-  const webPreferences = {
-    // Don't throttle animations/timers when backgrounded.
-    backgroundThrottling: false,
-    // Use native window.open so external windows can access their parent.
-    nativeWindowOpen: true
-  };
+  const webPreferences = getDefaultWebPreferences();
 
   // Load additional preferences from config.
   if (config.has('electron.webPreferences')) {

--- a/app/src/prefs.js
+++ b/app/src/prefs.js
@@ -1,0 +1,25 @@
+/**
+ * Get the default web preferences for Electron apps.
+ * @return {!Object}
+ */
+const getDefaultWebPreferences = () => ({
+  //
+  // Don't throttle animations/timers when backgrounded.
+  //
+  backgroundThrottling: false,
+
+  //
+  // Use native window.open so external windows can access their parent.
+  //
+  nativeWindowOpen: true,
+
+  //
+  // Execute preload scripts in an isolated context.
+  //
+  // https://www.electronjs.org/docs/tutorial/security#3-enable-context-isolation-for-remote-content
+  //
+  contextIsolation: true
+});
+
+
+module.exports = {getDefaultWebPreferences};

--- a/config/default.json
+++ b/config/default.json
@@ -1,22 +1,6 @@
 {
   "electron": {
     "appName": "OpenSphere",
-    "releaseUrl": "https://github.com/ngageoint/opensphere-electron/releases",
-    "webPreferences": {
-      //
-      // Enable web security to enforce CORS and prevent execution of insecure code.
-      //
-      // https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content
-      //
-      "webSecurity": true,
-      //
-      // Disable node integration to prevent XSS attacks from having access to it.
-      // If needed, introduce minimal interfaces through a preload script.
-      //
-      // https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content
-      //
-      "nodeIntegration": false,
-      "nodeIntegrationInWorker": false
-    }
+    "releaseUrl": "https://github.com/ngageoint/opensphere-electron/releases"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,17 +23,17 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "config": "^3.1.0",
+    "config": "^3.2.6",
     "electron-is-dev": "^1.1.0",
-    "electron-log": "^3.0.6",
-    "electron-updater": "^4.0.6",
+    "electron-log": "^4.0.6",
+    "electron-updater": "^4.2.2",
     "open": "^6.3.0",
     "slash": "^3.0.0"
   },
   "devDependencies": {
-    "electron": "5.0.4",
-    "electron-builder": "22.1.0",
-    "eslint": "^6.0.1",
-    "eslint-config-google": "^0.13.0"
+    "electron": "8.0.1",
+    "electron-builder": "22.3.2",
+    "eslint": "^6.8.0",
+    "eslint-config-google": "^0.14.0"
   }
 }


### PR DESCRIPTION
- Updated Electron to latest (currently 8.0.1).
- Fixed deprecated/changed API's.
- Enabled [contextIsolation](https://www.electronjs.org/docs/tutorial/security#3-enable-context-isolation-for-remote-content), per security recommendations.
- Removed `webPreferences` that are using Electron's default.
- Refactor pass to split some code out of `main.js` and follow Electron's JS style conventions.