### PR TITLE
Select client certificate

### DIFF
--- a/app/src/appenv.js
+++ b/app/src/appenv.js
@@ -1,3 +1,4 @@
+// Node Modules
 const config = require('config');
 const path = require('path');
 

--- a/app/src/appenv.js
+++ b/app/src/appenv.js
@@ -49,9 +49,6 @@ const initEnvVars = (osPath) => {
     // This allows scripts to add this to module.paths if they want to pick up
     // native deps built for electron out of opensphere-electron/app/node_modules
     process.env.ELECTRON_EXTRA_PATH = module.paths[1];
-  } else {
-    // When running in production, update the location for app configuration.
-    process.env.NODE_CONFIG_DIR = path.join(process.resourcesPath, 'config');
   }
 };
 

--- a/app/src/appenv.js
+++ b/app/src/appenv.js
@@ -1,0 +1,58 @@
+const config = require('config');
+const path = require('path');
+
+
+/**
+ * If Electron is running in a development environment.
+ * @type {boolean}
+ */
+const isDev = require('electron-is-dev');
+
+
+/**
+ * If Electron is running the debug application.
+ * @type {boolean}
+ */
+const isDebug = isDev && process.argv.includes('--debug');
+
+
+/**
+ * Base path for the Electron app.
+ * @type {string}
+ */
+const basePath = isDev ? path.resolve('..') : path.join(process.resourcesPath, 'app.asar');
+
+
+/**
+ * Location of the base application.
+ * @type {string}
+ */
+const baseApp = config.has('electron.baseApp') ? config.get('electron.baseApp') : 'opensphere';
+
+
+/**
+ * Location of preload scripts.
+ * @type {string}
+ */
+const preloadDir = path.join(__dirname, 'preload');
+
+
+/**
+ * Initialize environment variables based on the current environment.
+ * @param {string} osPath Base path to opensphere.
+ */
+const initEnvVars = (osPath) => {
+  if (isDev) {
+    process.env.ELECTRON_IS_DEV = isDev;
+
+    // This allows scripts to add this to module.paths if they want to pick up
+    // native deps built for electron out of opensphere-electron/app/node_modules
+    process.env.ELECTRON_EXTRA_PATH = module.paths[1];
+  } else {
+    // When running in production, update the location for app configuration.
+    process.env.NODE_CONFIG_DIR = path.join(process.resourcesPath, 'config');
+  }
+};
+
+
+module.exports = {baseApp, basePath, isDev, isDebug, initEnvVars, preloadDir};

--- a/app/src/appmenu.js
+++ b/app/src/appmenu.js
@@ -1,5 +1,8 @@
-const {app, BrowserWindow} = require('electron');
+// Node Modules
 const isDev = require('electron-is-dev');
+
+// Electron Modules
+const {app, BrowserWindow} = require('electron');
 
 const editMenu = {
   label: 'Edit',

--- a/app/src/appmenu.js
+++ b/app/src/appmenu.js
@@ -104,7 +104,7 @@ const windowMenu = {
 const template = [editMenu, viewMenu, windowMenu];
 
 if (process.platform === 'darwin') {
-  const name = app.getName();
+  const name = app.name;
   template.unshift({
     label: name,
     submenu: [{

--- a/app/src/apppath.js
+++ b/app/src/apppath.js
@@ -1,0 +1,73 @@
+const config = require('config');
+const path = require('path');
+const url = require('url');
+
+const appEnv = require('./appenv.js');
+
+
+/**
+ * Get the path for an application.
+ * @param {string} appName The application name.
+ * @param {string} basePath The base application path.
+ * @return {string} The application path.
+ */
+const getAppPath = (appName, basePath) => {
+  let appPath;
+
+  const configKey = `electron.apps.${appName}`;
+  const appConfig = config.has(configKey) ? config.get(configKey) : {};
+  const baseAppPath = appConfig.path || appName;
+
+  if (appEnv.isDev) {
+    // Development (command line) path
+    appPath = path.resolve(basePath, baseAppPath);
+
+    if (!appEnv.isDebug) {
+      // Compiled app
+      appPath = path.resolve(appPath, 'dist', baseAppPath);
+    }
+  } else {
+    // Production path
+    appPath = path.join(basePath, baseAppPath);
+  }
+
+  return appPath;
+};
+
+
+/**
+ * Get the URL to load an application.
+ * @param {string} appName The application name.
+ * @param {string} baseUrl The base application URL.
+ * @return {string} The application URL.
+ */
+const getAppUrl = (appName, baseUrl) => {
+  const appPath = getAppPath(appName, baseUrl);
+  return url.format({
+    pathname: path.join(appPath, 'index.html'),
+    protocol: 'file:',
+    slashes: true
+  });
+};
+
+
+/**
+ * Get the app name from a URL.
+ * @param {string} url The URL.
+ * @return {?string} The app name, or null if not found.
+ */
+const getAppFromUrl = (url) => {
+  let matchedApp = null;
+  if (config.has('electron.apps')) {
+    const apps = config.get('electron.apps');
+    for (const appName in apps) {
+      if (url.indexOf(appName) != -1 && (!matchedApp || matchedApp.length < appName.length)) {
+        matchedApp = appName;
+      }
+    }
+  }
+  return matchedApp;
+};
+
+
+module.exports = {getAppPath, getAppFromUrl, getAppUrl};

--- a/app/src/apppath.js
+++ b/app/src/apppath.js
@@ -1,7 +1,9 @@
+// Node Modules
 const config = require('config');
 const path = require('path');
 const url = require('url');
 
+// Local Modules
 const appEnv = require('./appenv.js');
 
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -1,10 +1,17 @@
+const path = require('path');
+
+// When running in production, update the location for app configuration. This must be done before config is first
+// required, or app configuration will not be loaded properly.
+if (!require('electron-is-dev')) {
+  process.env.NODE_CONFIG_DIR = path.join(process.resourcesPath, 'config');
+}
+
 // Node Modules
 const config = require('config');
 const fs = require('fs');
 const log = require('electron-log');
 const {autoUpdater} = require('electron-updater');
 const open = require('open');
-const path = require('path');
 const slash = require('slash');
 
 // Electron Modules

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -147,14 +147,12 @@ const createBrowserWindow = (webPreferences, parentWindow) => {
       event.preventDefault();
 
       getUserCertForUrl(url, list, browserWindow.webContents).then((cert) => {
-        // Allow this to be undefined in case the user cancels the prompt (ie, don't use a cert).
-        callback(cert || undefined);
+        callback(cert);
       }, (err) => {
-        const reason = err && err.message || 'unspecified reason';
+        // This intentionally doesn't call the callback, because Electron will remember the decision. If the app was
+        // refreshed, we want Electron to try selecting a cert again when the app loads.
+        const reason = err && err.message || 'Unspecified reason.';
         log.error(`Client certificate selection failed: ${reason}`);
-
-        // Don't use a certificate.
-        callback();
       });
     }
   });

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -1,13 +1,16 @@
-const {app, dialog, globalShortcut, protocol, shell, BrowserWindow, Menu} = require('electron');
-const {autoUpdater} = require('electron-updater');
-
+// Node Modules
 const config = require('config');
 const fs = require('fs');
 const log = require('electron-log');
+const {autoUpdater} = require('electron-updater');
 const open = require('open');
 const path = require('path');
 const slash = require('slash');
 
+// Electron Modules
+const {app, dialog, globalShortcut, protocol, shell, BrowserWindow, Menu} = require('electron');
+
+// Local Modules
 const appEnv = require('./appenv.js');
 const {getAppPath, getAppFromUrl, getAppUrl} = require('./apppath.js');
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -13,6 +13,7 @@ const {app, dialog, globalShortcut, protocol, shell, BrowserWindow, Menu} = requ
 // Local Modules
 const appEnv = require('./appenv.js');
 const {getAppPath, getAppFromUrl, getAppUrl} = require('./apppath.js');
+const {getDefaultWebPreferences} = require('./prefs.js');
 
 // Configure logger.
 log.transports.file.level = 'debug';
@@ -163,12 +164,7 @@ const createAppWindow = (appName, url, parentWindow) => {
  */
 const createMainWindow = () => {
   // Default web preferences for the main browser window.
-  const webPreferences = {
-    // Don't throttle animations/timers when backgrounded.
-    backgroundThrottling: false,
-    // Use native window.open so external windows can access their parent.
-    nativeWindowOpen: true
-  };
+  const webPreferences = getDefaultWebPreferences();
 
   // Load additional preferences from config.
   if (config.has('electron.webPreferences')) {

--- a/app/src/prefs.js
+++ b/app/src/prefs.js
@@ -1,0 +1,25 @@
+/**
+ * Get the default web preferences for Electron apps.
+ * @return {!Object}
+ */
+const getDefaultWebPreferences = () => ({
+  //
+  // Don't throttle animations/timers when backgrounded.
+  //
+  backgroundThrottling: false,
+
+  //
+  // Use native window.open so external windows can access their parent.
+  //
+  nativeWindowOpen: true,
+
+  //
+  // Execute preload scripts in an isolated context.
+  //
+  // https://www.electronjs.org/docs/tutorial/security#3-enable-context-isolation-for-remote-content
+  //
+  contextIsolation: true
+});
+
+
+module.exports = {getDefaultWebPreferences};

--- a/app/src/usercerts.js
+++ b/app/src/usercerts.js
@@ -1,0 +1,42 @@
+const Promise = require('bluebird');
+const {ipcMain} = require('electron');
+
+
+/**
+ * Map of request origin to Promise.
+ * @type {Object<string, !Promise>}
+ */
+const promises = {};
+
+
+/**
+ * Get the user certificate to use for the provided URL.
+ * @param {string} url The URL.
+ * @param {Array<Certificate>} list Available user certificates.
+ * @param {WebContents} webContents The WebContents instance requesting a certificate.
+ * @return {Promise} A promise that resolves to the selected certificate.
+ */
+const getUserCertForUrl = (url, list, webContents) => {
+  if (!url) {
+    return Promise.reject(new Error('URL for certificate request was empty.'));
+  }
+
+  if (!promises[url]) {
+    promises[url] = new Promise((resolve, reject) => {
+      const callback = (event, eventUrl, cert) => {
+        if (eventUrl === url) {
+          ipcMain.removeListener('client-certificate-selected', callback);
+          resolve(cert);
+        }
+      };
+
+      ipcMain.on('client-certificate-selected', callback);
+      webContents.send('select-client-certificate', url, list);
+    });
+  }
+
+  return promises[url];
+};
+
+
+module.exports = {getUserCertForUrl};

--- a/app/src/usercerts.js
+++ b/app/src/usercerts.js
@@ -4,7 +4,7 @@ const {ipcMain} = require('electron');
 
 /**
  * Map of request origin to Promise.
- * @type {Object<string, !Promise>}
+ * @type {Object<string, !Promise<!Electron.Certificate>>}
  */
 const promises = {};
 
@@ -12,9 +12,9 @@ const promises = {};
 /**
  * Get the user certificate to use for the provided URL.
  * @param {string} url The URL.
- * @param {Array<Certificate>} list Available user certificates.
+ * @param {!Array<!Certificate>} list Available user certificates.
  * @param {WebContents} webContents The WebContents instance requesting a certificate.
- * @return {Promise} A promise that resolves to the selected certificate.
+ * @return {!Promise<!Electron.Certificate>} A promise that resolves to the selected certificate.
  */
 const getUserCertForUrl = (url, list, webContents) => {
   if (!url) {
@@ -26,12 +26,27 @@ const getUserCertForUrl = (url, list, webContents) => {
       const callback = (event, eventUrl, cert) => {
         if (eventUrl === url) {
           ipcMain.removeListener('client-certificate-selected', callback);
-          resolve(cert);
+
+          // An explicit undefined value means the user did not make a choice (ie, page reload), null means the user
+          // cancelled the request and a cert should not be used.
+          if (cert === undefined) {
+            delete promises[url];
+            reject(new Error('Certificate could not be selected by the user.'));
+          } else {
+            resolve(cert);
+          }
         }
       };
 
       ipcMain.on('client-certificate-selected', callback);
       webContents.send('select-client-certificate', url, list);
+    });
+
+    // If the promise is rejected due to page unload, remove the promise so the new session will try again.
+    promises[url].then(undefined, (err) => {
+      if (err && err.message === 'unload') {
+        delete promises[url];
+      }
     });
   }
 

--- a/config/default.json
+++ b/config/default.json
@@ -1,22 +1,6 @@
 {
   "electron": {
     "appName": "OpenSphere",
-    "releaseUrl": "https://github.com/ngageoint/opensphere-electron/releases",
-    "webPreferences": {
-      //
-      // Enable web security to enforce CORS and prevent execution of insecure code.
-      //
-      // https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content
-      //
-      "webSecurity": true,
-      //
-      // Disable node integration to prevent XSS attacks from having access to it.
-      // If needed, introduce minimal interfaces through a preload script.
-      //
-      // https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content
-      //
-      "nodeIntegration": false,
-      "nodeIntegrationInWorker": false
-    }
+    "releaseUrl": "https://github.com/ngageoint/opensphere-electron/releases"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "bluebird": "^3.7.2",
     "config": "^3.2.6",
     "electron-is-dev": "^1.1.0",
     "electron-log": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -23,17 +23,17 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "config": "^3.1.0",
+    "config": "^3.2.6",
     "electron-is-dev": "^1.1.0",
-    "electron-log": "^3.0.6",
-    "electron-updater": "^4.0.6",
+    "electron-log": "^4.0.6",
+    "electron-updater": "^4.2.2",
     "open": "^6.3.0",
     "slash": "^3.0.0"
   },
   "devDependencies": {
-    "electron": "5.0.4",
-    "electron-builder": "22.1.0",
-    "eslint": "^6.0.1",
-    "eslint-config-google": "^0.13.0"
+    "electron": "8.0.1",
+    "electron-builder": "22.3.2",
+    "eslint": "^6.8.0",
+    "eslint-config-google": "^0.14.0"
   }
 }


### PR DESCRIPTION
OpenSphere PR: https://github.com/ngageoint/opensphere/pull/891

**Note:** This was branched from https://github.com/ngageoint/opensphere-electron/pull/16 and contains additional commits from the described changes. This will be resolved when that gets merged, but for now reviews should start at 25510b5.

Electron does not natively support prompting a user to select a certificate, and always chooses the first one in its internal list. This PR allows applications running in Electron to register a callback so they may prompt the user to select a certificate. When the user has multiple certificates, the main process will send the certificate list to the application so it may prompt the user. If the user does not have multiple certificates, the main process will defer to Electron's default behavior.