### PR TITLE
fix(app): improve app URL detection to avoid false positives

### DIFF
--- a/app/src/appenv.js
+++ b/app/src/appenv.js
@@ -32,6 +32,22 @@ const baseApp = config.has('electron.baseApp') ? config.get('electron.baseApp') 
 
 
 /**
+ * The base path to the application icon.
+ * @type {string}
+ */
+const iconBasePath = isDev ?
+    (config.has('electron.iconDev') ? config.get('electron.iconDev') : '') :
+    (config.has('electron.icon') ? config.get('electron.icon') : '');
+
+
+/**
+ * The application icon.
+ * @type {string}
+ */
+const iconPath = iconBasePath ? path.resolve(basePath, iconBasePath) : '';
+
+
+/**
  * Location of preload scripts.
  * @type {string}
  */
@@ -53,4 +69,4 @@ const initEnvVars = (osPath) => {
 };
 
 
-module.exports = {baseApp, basePath, isDev, isDebug, initEnvVars, preloadDir};
+module.exports = {baseApp, basePath, iconPath, isDev, isDebug, initEnvVars, preloadDir};

--- a/app/src/apppath.js
+++ b/app/src/apppath.js
@@ -1,7 +1,7 @@
 // Node Modules
 const config = require('config');
 const path = require('path');
-const url = require('url');
+const {URL, format} = require('url');
 
 // Local Modules
 const appEnv = require('./appenv.js');
@@ -45,7 +45,7 @@ const getAppPath = (appName, basePath) => {
  */
 const getAppUrl = (appName, baseUrl) => {
   const appPath = getAppPath(appName, baseUrl);
-  return url.format({
+  return format({
     pathname: path.join(appPath, 'index.html'),
     protocol: 'file:',
     slashes: true
@@ -62,9 +62,13 @@ const getAppFromUrl = (url) => {
   let matchedApp = null;
   if (config.has('electron.apps')) {
     const apps = config.get('electron.apps');
-    for (const appName in apps) {
-      if (url.indexOf(appName) != -1 && (!matchedApp || matchedApp.length < appName.length)) {
-        matchedApp = appName;
+
+    // Try matching an app path, starting from the end of the URL pathname
+    const parts = new URL(url).pathname.split('/').reverse();
+    for (const part of parts) {
+      if (apps.hasOwnProperty(part)) {
+        matchedApp = part;
+        break;
       }
     }
   }

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -165,6 +165,24 @@ const createBrowserWindow = (webPreferences, parentWindow) => {
     }
   });
 
+  browserWindow.webContents.on('will-prevent-unload', (event) => {
+    // The app is attempting to cancel the unload event. Prompt the user to allow this or not.
+    const choice = dialog.showMessageBoxSync(browserWindow, {
+      type: 'info',
+      buttons: ['Leave', 'Stay'],
+      icon: appEnv.iconPath || undefined,
+      title: 'Warning!',
+      message: 'You have unsaved changes on this page. If you navigate away from this page, your ' +
+          'changes will be lost.',
+      defaultId: 0,
+      cancelId: 1
+    });
+
+    if (choice === 0) {
+      event.preventDefault();
+    }
+  });
+
   return browserWindow;
 };
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -139,10 +139,11 @@ const createBrowserWindow = (webPreferences, parentWindow) => {
     if (decodedUrl.startsWith('file://') && decodedUrl.indexOf(slash(appEnv.basePath)) > -1) {
       const appName = getAppFromUrl(url);
       if (appName) {
-        event.preventDefault();
-
         // Get the actual app URL, appended with any fragment/query string from the requested URL.
         const appUrl = getAppUrl(appName, appEnv.basePath) + url.replace(/^[^#?]+/, '');
+        log.debug(`Loading app URL: ${appUrl}`);
+
+        event.preventDefault();
         browserWindow.loadURL(appUrl);
       }
     }
@@ -178,6 +179,8 @@ const createAppWindow = (appName, url, parentWindow) => {
   const appUrl = getAppUrl(appName, appEnv.basePath) + url.replace(/^[^#?]+/, '');
 
   if (parentWindow && parentWindow.webContents) {
+    log.debug(`Launching app ${appName} with URL ${appUrl}`);
+
     const appWindow = createBrowserWindow(parentWindow.webContents.getWebPreferences(), parentWindow);
     appWindow.loadURL(appUrl);
   }


### PR DESCRIPTION
There were still cases where the app name would not be detected correctly in the URL, such as `opensphere` being detected when running from `opensphere-electron`. The new approach finds exact matches from the URL pathname parts (instead of using `indexOf` on the entire URL), starting from the last part.