### PR TITLE
feat(menu): add history menu with back/forward/home

### DIFF
--- a/app/src/appmenu.js
+++ b/app/src/appmenu.js
@@ -2,7 +2,13 @@
 const isDev = require('electron-is-dev');
 
 // Electron Modules
-const {app, BrowserWindow} = require('electron');
+const {app, BrowserWindow, Menu} = require('electron');
+
+/**
+ * The app's home URL, used for the History > Home menu item.
+ * @type {string}
+ */
+let homeUrl = '';
 
 const editMenu = {
   label: 'Edit',
@@ -55,9 +61,7 @@ const viewMenu = {
     }
   }, {
     label: 'Toggle Full Screen',
-    accelerator: (function() {
-      return process.platform === 'darwin' ? 'Ctrl+Command+F' : 'F11';
-    })(),
+    accelerator: process.platform === 'darwin' ? 'Ctrl+Command+F' : 'F11',
     click: function(item, focusedWindow) {
       if (focusedWindow) {
         focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
@@ -69,9 +73,7 @@ const viewMenu = {
 if (isDev) {
   viewMenu.submenu.push({
     label: 'Toggle Developer Tools',
-    accelerator: (function() {
-      return process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I';
-    })(),
+    accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
     click: function(item, focusedWindow) {
       if (focusedWindow) {
         focusedWindow.toggleDevTools();
@@ -79,6 +81,35 @@ if (isDev) {
     }
   });
 }
+
+const historyMenu = {
+  label: 'History',
+  submenu: [{
+    label: 'Home',
+    accelerator: process.platform === 'darwin' ? 'Command+Shift+H' : 'Alt+Home',
+    click: function(item, focusedWindow) {
+      if (focusedWindow && homeUrl) {
+        focusedWindow.loadURL(homeUrl);
+      }
+    }
+  }, {
+    label: 'Back',
+    accelerator: process.platform === 'darwin' ? 'Command+Left' : 'Alt+Left',
+    click: function(item, focusedWindow) {
+      if (focusedWindow && focusedWindow.webContents) {
+        focusedWindow.webContents.goBack();
+      }
+    }
+  }, {
+    label: 'Forward',
+    accelerator: process.platform === 'darwin' ? 'Command+Right' : 'Alt+Right',
+    click: function(item, focusedWindow) {
+      if (focusedWindow && focusedWindow.webContents) {
+        focusedWindow.webContents.goForward();
+      }
+    }
+  }]
+};
 
 const windowMenu = {
   label: 'Window',
@@ -104,7 +135,7 @@ const windowMenu = {
   }]
 };
 
-const template = [editMenu, viewMenu, windowMenu];
+const template = [editMenu, viewMenu, historyMenu, windowMenu];
 
 if (process.platform === 'darwin') {
   const name = app.name;
@@ -151,4 +182,23 @@ if (process.platform === 'darwin') {
   }
 }
 
-module.exports = template;
+
+/**
+ * Update the application menu.
+ */
+const updateAppMenu = () => {
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+};
+
+
+/**
+ * Set the home URL for the application.
+ * @param  {string} url The URL.
+ */
+const setHomeUrl = (url) => {
+  homeUrl = url;
+};
+
+
+module.exports = {updateAppMenu, setHomeUrl};

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -106,6 +106,14 @@ const createBrowserWindow = (webPreferences, parentWindow) => {
     callback({cancel: false, responseHeaders: details.responseHeaders});
   });
 
+  browserWindow.webContents.on('did-navigate', (event) => {
+    appMenu.updateHistoryMenu();
+  });
+
+  browserWindow.webContents.on('did-navigate-in-page', (event) => {
+    appMenu.updateHistoryMenu();
+  });
+
   browserWindow.webContents.on('new-window', (event, url, frameName) => {
     log.debug(`Event [new-window]: ${url}`);
 
@@ -257,7 +265,7 @@ app.on('ready', () => {
   loadConfig();
 
   // Set up the application menu.
-  appMenu.updateAppMenu();
+  appMenu.createAppMenu();
 
   // Launch the application.
   createMainWindow();
@@ -278,7 +286,6 @@ app.on('ready', () => {
     autoUpdater.checkForUpdates();
   }
 });
-
 
 app.on('window-all-closed', () => {
   // On OS X it is common for applications and their menu bar

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -106,10 +106,12 @@ const createBrowserWindow = (webPreferences, parentWindow) => {
     callback({cancel: false, responseHeaders: details.responseHeaders});
   });
 
+  // Update history menu (forward/back state) on navigation.
   browserWindow.webContents.on('did-navigate', (event) => {
     appMenu.updateHistoryMenu();
   });
 
+  // Update history menu (forward/back state) on page navigation (URL hash change).
   browserWindow.webContents.on('did-navigate-in-page', (event) => {
     appMenu.updateHistoryMenu();
   });

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -15,10 +15,11 @@ const open = require('open');
 const slash = require('slash');
 
 // Electron Modules
-const {app, dialog, globalShortcut, protocol, shell, BrowserWindow, Menu} = require('electron');
+const {app, dialog, globalShortcut, protocol, shell, BrowserWindow} = require('electron');
 
 // Local Modules
 const appEnv = require('./appenv.js');
+const appMenu = require('./appmenu.js');
 const {getAppPath, getAppFromUrl, getAppUrl} = require('./apppath.js');
 const {getUserCertForUrl} = require('./usercerts.js');
 const {getDefaultWebPreferences} = require('./prefs.js');
@@ -224,6 +225,7 @@ const createMainWindow = () => {
 
   // Load the app from the file system.
   const appUrl = getAppUrl(appEnv.baseApp, appEnv.basePath);
+  appMenu.setHomeUrl(appUrl);
 
   log.info('loading', appUrl);
   mainWindow.loadURL(appUrl);
@@ -255,9 +257,7 @@ app.on('ready', () => {
   loadConfig();
 
   // Set up the application menu.
-  const template = require('./appmenu.js');
-  const menu = Menu.buildFromTemplate(template);
-  Menu.setApplicationMenu(menu);
+  appMenu.updateAppMenu();
 
   // Launch the application.
   createMainWindow();


### PR DESCRIPTION
Added a History menu with simple navigation items to assist page nav in multi-page apps. This mimics Chrome's History menu/shortcuts.