### PR TITLE
refactor(main): move additional code out of main.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,17 +1,21 @@
 module.exports = {
   "extends": "google",
-  "parserOptions": {
-    "ecmaVersion": 6
+  "env": {
+    "es6": true,
+    "node": true
   },
   "rules": {
-    // don't dangle commas
+    // Don't dangle commas.
     "comma-dangle": ["error", "never"],
-    // pre-ES6 engines need to be able to use objects as maps
+    // Pre-ES6 engines need to be able to use objects as maps.
     "guard-for-in": "off",
-    // increase max line length
+    // Increase max line length.
     "max-len": ["error", { "code": 120 }],
     // This is silly. Negated conditions are highly useful and often much more concise than
     // their complements.
-    "no-negated-condition": "off"
+    "no-negated-condition": "off",
+    // Error on undeclared variables. Google disables this because it causes problems with Closure-style JS, where
+    // namespaces are globally defined. In modularized JS, this is a highly useful error.
+    "no-undef": "error"
   }
 };

--- a/app/src/appmenu.js
+++ b/app/src/appmenu.js
@@ -1,10 +1,13 @@
 // Node Modules
+const config = require('config');
 const isDev = require('electron-is-dev');
 
 // Electron Modules
-const {app, BrowserWindow, Menu} = require('electron');
+const {app, globalShortcut, BrowserWindow, Menu} = require('electron');
 
 // Local Modules
+const appEnv = require('./appenv.js');
+const {getAppUrl} = require('./apppath.js');
 const {checkForUpdates} = require('./autoupdate.js');
 
 
@@ -13,13 +16,12 @@ const {checkForUpdates} = require('./autoupdate.js');
  */
 let appMenu;
 
-/**
- * The app's home URL, used for the History > Home menu item.
- * @type {string}
- */
-let homeUrl = '';
 
-const editMenu = {
+/**
+ * Create the Edit application menu.
+ * @return {!Object} The menu configuration.
+ */
+const createEditMenu = () => ({
   label: 'Edit',
   submenu: [{
     label: 'Undo',
@@ -48,113 +50,174 @@ const editMenu = {
     accelerator: 'CmdOrCtrl+A',
     role: 'selectall'
   }]
-};
+});
 
-const viewMenu = {
-  label: 'View',
-  submenu: [{
-    label: 'Reload',
-    accelerator: 'CmdOrCtrl+R',
-    click: function(item, focusedWindow) {
-      if (focusedWindow) {
-        // on reload, start fresh and close any old open secondary windows
-        if (focusedWindow.id === 1) {
-          BrowserWindow.getAllWindows().forEach(function(win) {
-            if (win.id > 1) {
-              win.close();
-            }
-          });
+
+/**
+ * Create the View application menu.
+ * @return {!Object} The menu configuration.
+ */
+const createViewMenu = () => {
+  const menu = {
+    label: 'View',
+    submenu: [{
+      label: 'Reload',
+      accelerator: 'CmdOrCtrl+R',
+      click: (item, focusedWindow) => {
+        if (focusedWindow) {
+          // on reload, start fresh and close any old open secondary windows
+          if (focusedWindow.id === 1) {
+            BrowserWindow.getAllWindows().forEach((win) => {
+              if (win.id > 1) {
+                win.close();
+              }
+            });
+          }
+          focusedWindow.reload();
         }
-        focusedWindow.reload();
       }
-    }
-  }, {
-    label: 'Toggle Full Screen',
-    accelerator: process.platform === 'darwin' ? 'Ctrl+Command+F' : 'F11',
-    click: function(item, focusedWindow) {
-      if (focusedWindow) {
-        focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+    }, {
+      label: 'Toggle Full Screen',
+      accelerator: process.platform === 'darwin' ? 'Ctrl+Command+F' : 'F11',
+      click: (item, focusedWindow) => {
+        if (focusedWindow) {
+          focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+        }
       }
-    }
-  }]
-};
+    }]
+  };
 
-if (isDev) {
-  viewMenu.submenu.push({
-    label: 'Toggle Developer Tools',
-    accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-    click: function(item, focusedWindow) {
+  if (isDev) {
+    menu.submenu.push({
+      label: 'Toggle Developer Tools',
+      accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+      click: (item, focusedWindow) => {
+        if (focusedWindow) {
+          focusedWindow.toggleDevTools();
+        }
+      }
+    });
+  } else {
+    // Allow opening Dev Tools via shortcut.
+    const shortcut = process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I';
+    globalShortcut.register(shortcut, () => {
+      const focusedWindow = BrowserWindow.getFocusedWindow();
       if (focusedWindow) {
         focusedWindow.toggleDevTools();
       }
-    }
-  });
-}
+    });
+  }
 
+  return menu;
+};
+
+
+/**
+ * History menu item identifiers.
+ * @enum {string}
+ */
 const HistoryItemId = {
   BACK: 'go-back',
   FORWARD: 'go-forward',
   HOME: 'go-home'
 };
 
-const historyMenu = {
-  label: 'History',
-  submenu: [{
-    id: HistoryItemId.HOME,
-    label: 'Home',
-    visible: false,
-    accelerator: process.platform === 'darwin' ? 'Command+Shift+H' : 'Alt+Home',
-    click: function(item, focusedWindow) {
-      if (focusedWindow && homeUrl) {
-        focusedWindow.loadURL(homeUrl);
+
+/**
+ * Create the History application menu.
+ * @return {!Object} The menu configuration.
+ */
+const createHistoryMenu = () => {
+  // Only add the history menu if other apps are defined. By default, OpenSphere is a single-page app and does not
+  // benefit from navigation.
+  if (!config.has('electron.apps')) {
+    return null;
+  }
+
+  const homeUrl = getAppUrl(appEnv.baseApp, appEnv.basePath);
+
+  return {
+    label: 'History',
+    submenu: [{
+      id: HistoryItemId.HOME,
+      label: 'Home',
+      visible: !!homeUrl,
+      accelerator: process.platform === 'darwin' ? 'Command+Shift+H' : 'Alt+Home',
+      click: (item, focusedWindow) => {
+        if (focusedWindow && homeUrl) {
+          focusedWindow.loadURL(homeUrl);
+        }
       }
-    }
-  }, {
-    id: HistoryItemId.BACK,
-    label: 'Back',
-    accelerator: process.platform === 'darwin' ? 'Command+Left' : 'Alt+Left',
-    click: function(item, focusedWindow) {
-      if (focusedWindow && focusedWindow.webContents) {
-        focusedWindow.webContents.goBack();
+    }, {
+      id: HistoryItemId.BACK,
+      label: 'Back',
+      accelerator: process.platform === 'darwin' ? 'Command+Left' : 'Alt+Left',
+      click: (item, focusedWindow) => {
+        if (focusedWindow && focusedWindow.webContents) {
+          focusedWindow.webContents.goBack();
+        }
       }
-    }
-  }, {
-    id: HistoryItemId.FORWARD,
-    label: 'Forward',
-    accelerator: process.platform === 'darwin' ? 'Command+Right' : 'Alt+Right',
-    click: function(item, focusedWindow) {
-      if (focusedWindow && focusedWindow.webContents) {
-        focusedWindow.webContents.goForward();
+    }, {
+      id: HistoryItemId.FORWARD,
+      label: 'Forward',
+      accelerator: process.platform === 'darwin' ? 'Command+Right' : 'Alt+Right',
+      click: (item, focusedWindow) => {
+        if (focusedWindow && focusedWindow.webContents) {
+          focusedWindow.webContents.goForward();
+        }
       }
-    }
-  }]
+    }]
+  };
 };
 
-const windowMenu = {
-  label: 'Window',
-  role: 'window',
-  submenu: [{
-    label: 'Minimize',
-    accelerator: 'CmdOrCtrl+M',
-    role: 'minimize'
-  }, {
-    label: 'Close',
-    accelerator: 'CmdOrCtrl+W',
-    role: 'close'
-  }, {
-    type: 'separator'
-  }, {
-    label: 'Reopen Window',
-    accelerator: 'CmdOrCtrl+Shift+T',
-    enabled: false,
-    key: 'reopenMenuItem',
-    click: function() {
-      app.emit('activate');
-    }
-  }]
+
+/**
+ * Create the Window application menu.
+ * @return {!Object} The menu configuration.
+ */
+const createWindowMenu = () => {
+  const menu = {
+    label: 'Window',
+    role: 'window',
+    submenu: [{
+      label: 'Minimize',
+      accelerator: 'CmdOrCtrl+M',
+      role: 'minimize'
+    }, {
+      label: 'Close',
+      accelerator: 'CmdOrCtrl+W',
+      role: 'close'
+    }, {
+      type: 'separator'
+    }, {
+      label: 'Reopen Window',
+      accelerator: 'CmdOrCtrl+Shift+T',
+      enabled: false,
+      key: 'reopenMenuItem',
+      click: () => {
+        app.emit('activate');
+      }
+    }]
+  };
+
+  if (process.platform === 'darwin') {
+    menu.submenu.push({
+      type: 'separator'
+    }, {
+      label: 'Bring All to Front',
+      role: 'front'
+    });
+  }
+
+  return menu;
 };
 
-const helpMenu = {
+
+/**
+ * Create the Help application menu.
+ * @return {!Object} The menu configuration.
+ */
+const createHelpMenu = () => ({
   label: 'Help',
   submenu: [{
     label: 'Check for Updates...',
@@ -162,54 +225,56 @@ const helpMenu = {
       checkForUpdates(true);
     }
   }]
-};
+});
 
-const template = [editMenu, viewMenu, historyMenu, windowMenu, helpMenu];
 
-if (process.platform === 'darwin') {
-  const name = app.name;
-  template.unshift({
-    label: name,
-    submenu: [{
-      label: `About ${name}`,
-      role: 'about'
-    }, {
-      type: 'separator'
-    }, {
-      label: `Hide ${name}`,
-      accelerator: 'Command+H',
-      role: 'hide'
-    }, {
-      label: 'Hide Others',
-      accelerator: 'Command+Alt+H',
-      role: 'hideothers'
-    }, {
-      label: 'Show All',
-      role: 'unhide'
-    }, {
-      type: 'separator'
-    }, {
-      label: 'Quit',
-      accelerator: 'Command+Q',
-      click: function() {
-        app.quit();
-      }
-    }]
-  });
+/**
+ * Create the menu configuration template.
+ * @return {!Array<!Object>}
+ */
+const createTemplate = () => {
+  const editMenu = createEditMenu();
+  const viewMenu = createViewMenu();
+  const historyMenu = createHistoryMenu();
+  const windowMenu = createWindowMenu();
+  const helpMenu = createHelpMenu();
 
-  const windowMenu = template.find(function(item) {
-    return item.label === 'Window';
-  });
+  const template = [editMenu, viewMenu, historyMenu, windowMenu, helpMenu].filter((menu) => !!menu);
 
-  if (windowMenu) {
-    windowMenu.submenu.push({
-      type: 'separator'
-    }, {
-      label: 'Bring All to Front',
-      role: 'front'
+  if (process.platform === 'darwin') {
+    const name = app.name;
+    template.unshift({
+      label: name,
+      submenu: [{
+        label: `About ${name}`,
+        role: 'about'
+      }, {
+        type: 'separator'
+      }, {
+        label: `Hide ${name}`,
+        accelerator: 'Command+H',
+        role: 'hide'
+      }, {
+        label: 'Hide Others',
+        accelerator: 'Command+Alt+H',
+        role: 'hideothers'
+      }, {
+        label: 'Show All',
+        role: 'unhide'
+      }, {
+        type: 'separator'
+      }, {
+        label: 'Quit',
+        accelerator: 'Command+Q',
+        click: () => {
+          app.quit();
+        }
+      }]
     });
   }
-}
+
+  return template;
+};
 
 
 /**
@@ -217,6 +282,8 @@ if (process.platform === 'darwin') {
  */
 const createAppMenu = () => {
   if (!appMenu) {
+    const template = createTemplate();
+
     appMenu = Menu.buildFromTemplate(template);
     Menu.setApplicationMenu(appMenu);
 
@@ -232,36 +299,32 @@ const createAppMenu = () => {
  * Update the history menu.
  */
 const updateHistoryMenu = () => {
-  if (appMenu) {
-    const homeItem = appMenu.getMenuItemById(HistoryItemId.HOME);
-    if (homeItem) {
-      homeItem.visible = !!homeUrl;
+  const focusedWindow = BrowserWindow.getFocusedWindow();
+  if (appMenu && focusedWindow) {
+    const backItem = appMenu.getMenuItemById(HistoryItemId.BACK);
+    if (backItem) {
+      backItem.enabled = focusedWindow.webContents.canGoBack();
     }
 
-    const focusedWindow = BrowserWindow.getFocusedWindow();
-    if (focusedWindow) {
-      const backItem = appMenu.getMenuItemById(HistoryItemId.BACK);
-      if (backItem) {
-        backItem.enabled = focusedWindow.webContents.canGoBack();
-      }
-
-      const forwardItem = appMenu.getMenuItemById(HistoryItemId.FORWARD);
-      if (forwardItem) {
-        forwardItem.enabled = focusedWindow.webContents.canGoForward();
-      }
+    const forwardItem = appMenu.getMenuItemById(HistoryItemId.FORWARD);
+    if (forwardItem) {
+      forwardItem.enabled = focusedWindow.webContents.canGoForward();
     }
   }
 };
 
 
-/**
- * Set the home URL for the application.
- * @param  {string} url The URL.
- */
-const setHomeUrl = (url) => {
-  homeUrl = url;
-  updateHistoryMenu();
-};
+app.on('web-contents-created', (event, contents) => {
+  // Update history menu (forward/back state) on navigation.
+  contents.on('did-navigate', (event) => {
+    updateHistoryMenu();
+  });
+
+  // Update history menu (forward/back state) on page navigation (URL hash change).
+  contents.on('did-navigate-in-page', (event) => {
+    updateHistoryMenu();
+  });
+});
 
 
-module.exports = {createAppMenu, setHomeUrl, updateHistoryMenu};
+module.exports = {createAppMenu, updateHistoryMenu};

--- a/app/src/appnav.js
+++ b/app/src/appnav.js
@@ -1,0 +1,169 @@
+// Node Modules
+const fs = require('fs');
+const log = require('electron-log');
+const path = require('path');
+const slash = require('slash');
+
+// Electron Modules
+const {dialog, shell, BrowserWindow} = require('electron');
+
+// Local Modules
+const appEnv = require('./appenv.js');
+const {getAppFromUrl, getAppUrl} = require('./apppath.js');
+
+
+/**
+ * XHR response headers that should be discarded.
+ * @type {!Array<string>}
+ */
+const discardedHeaders = [
+  'content-security-policy',
+  'x-frame-options',
+  'x-xss-protection'
+];
+
+
+/**
+ * Open an application browser window.
+ * @param {string} appName The app name.
+ * @param {string} url The app URL.
+ * @param {BrowserWindow} parentWindow The opening browser window.
+ */
+const createAppWindow = (appName, url, parentWindow) => {
+  // Get the actual app URL, appended with any fragment/query string from the requested URL.
+  const appUrl = getAppUrl(appName, appEnv.basePath) + url.replace(/^[^#?]+/, '');
+
+  if (parentWindow && parentWindow.webContents) {
+    log.debug(`Launching app ${appName} with URL ${appUrl}`);
+
+    const appWindow = createBrowserWindow(parentWindow.webContents.getWebPreferences(), parentWindow);
+    appWindow.loadURL(appUrl);
+  }
+};
+
+
+/**
+ * Create a new browser window.
+ * @param {WebPreferences} webPreferences The Electron web preferences.
+ * @param {BrowserWindow} parentWindow The opening browser window.
+ * @return {BrowserWindow}
+ */
+const createBrowserWindow = (webPreferences, parentWindow) => {
+  // Create the browser window.
+  const parentBounds = parentWindow ? parentWindow.getBounds() : undefined;
+  const browserWindow = new BrowserWindow({
+    width: parentBounds ? parentBounds.width : 1600,
+    height: parentBounds ? parentBounds.height : 900,
+    x: parentBounds ? (parentBounds.x + 25) : undefined,
+    y: parentBounds ? (parentBounds.y + 25) : undefined,
+    webPreferences: webPreferences
+  });
+
+  // Load external preload scripts into the session.
+  if (fs.existsSync(appEnv.preloadDir)) {
+    const preloads = fs.readdirSync(appEnv.preloadDir);
+    browserWindow.webContents.session.setPreloads(preloads.map(getPreloadPath));
+  }
+
+  // Delete X-Frame-Options header from XHR responses to avoid preventing URL's from displaying in an iframe.
+  browserWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+    const headers = Object.keys(details.responseHeaders);
+    headers.forEach((header) => {
+      if (discardedHeaders.includes(header.toLowerCase())) {
+        delete details.responseHeaders[header];
+      }
+    });
+
+    callback({cancel: false, responseHeaders: details.responseHeaders});
+  });
+
+  browserWindow.webContents.on('new-window', (event, url, frameName) => {
+    log.debug(`Event [new-window]: ${url}`);
+
+    // Any path outside of the application should be opened in the system browser
+    // Reasons:
+    //   1. That's what the user expects
+    //   2. That's where all of their login sessions/cookies already are
+    //   3. We've purposely axed CORS and XSS security from Electron so that the
+    //      user isn't bothered by that nonsense in a desktop app. As soon as you
+    //      treat Electron as a generic browser, that tears a hole in everything.
+    const decodedUrl = decodeURIComponent(url);
+    if (decodedUrl.indexOf('about:blank') === -1 &&
+        !(decodedUrl.startsWith('file://') && decodedUrl.indexOf(slash(appEnv.basePath)) > -1)) {
+      event.preventDefault();
+      openExternal(url);
+    } else if (url.indexOf('.html') == -1) {
+      // If the HTML file isn't specified in an internal URL, check if a matching app is configured.
+      const appName = getAppFromUrl(url);
+      if (appName) {
+        // Launch the matched app.
+        event.preventDefault();
+        createAppWindow(appName, url, browserWindow);
+      }
+    }
+  });
+
+  browserWindow.webContents.on('will-navigate', (event, url) => {
+    log.debug(`Event [will-navigate]: ${url}`);
+
+    // Internal navigation needs to detect when navigating to a configured app and get the correct URL for that app.
+    const decodedUrl = decodeURIComponent(url);
+    if (decodedUrl.startsWith('file://') && decodedUrl.indexOf(slash(appEnv.basePath)) > -1) {
+      const appName = getAppFromUrl(url);
+      if (appName) {
+        // Get the actual app URL, appended with any fragment/query string from the requested URL.
+        const appUrl = getAppUrl(appName, appEnv.basePath) + url.replace(/^[^#?]+/, '');
+        log.debug(`Loading app URL: ${appUrl}`);
+
+        event.preventDefault();
+        browserWindow.loadURL(appUrl);
+      }
+    } else {
+      event.preventDefault();
+      openExternal(url);
+    }
+  });
+
+  browserWindow.webContents.on('will-prevent-unload', (event) => {
+    // The app is attempting to cancel the unload event. Prompt the user to allow this or not.
+    const choice = dialog.showMessageBoxSync(browserWindow, {
+      type: 'info',
+      buttons: ['Leave', 'Stay'],
+      icon: appEnv.iconPath || undefined,
+      title: 'Warning!',
+      message: 'You have unsaved changes on this page. If you navigate away from this page, your ' +
+          'changes will be lost.',
+      defaultId: 0,
+      cancelId: 1
+    });
+
+    if (choice === 0) {
+      event.preventDefault();
+    }
+  });
+
+  return browserWindow;
+};
+
+
+/**
+ * Get the absolute path for a preload script.
+ * @param {string} script The script.
+ * @return {string} The absolute path.
+ */
+const getPreloadPath = (script) => {
+  return path.join(appEnv.preloadDir, script);
+};
+
+
+/**
+ * Open a URL using the desktop's default manner.
+ * @param {string} url The URL to open.
+ */
+const openExternal = (url) => {
+  log.debug(`Opening external window: ${url}`);
+  shell.openExternal(url);
+};
+
+
+module.exports = {createBrowserWindow, openExternal};

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -3,21 +3,18 @@ require('./initapp.js');
 
 // Node Modules
 const config = require('config');
-const fs = require('fs');
 const log = require('electron-log');
-const open = require('open');
-const path = require('path');
-const slash = require('slash');
 
 // Electron Modules
-const {app, dialog, globalShortcut, protocol, BrowserWindow} = require('electron');
+const {app, protocol, BrowserWindow} = require('electron');
 
 // Local Modules
 const appEnv = require('./appenv.js');
 const appMenu = require('./appmenu.js');
-const {getAppPath, getAppFromUrl, getAppUrl} = require('./apppath.js');
+const {createBrowserWindow} = require('./appnav.js');
+const {getAppPath, getAppUrl} = require('./apppath.js');
 const {disposeAutoUpdate, initAutoUpdate} = require('./autoupdate.js');
-const {getUserCertForUrl} = require('./usercerts.js');
+const {getClientCertificate} = require('./usercerts.js');
 const {getDefaultWebPreferences} = require('./prefs.js');
 
 // Configure logger.
@@ -34,13 +31,6 @@ appEnv.initEnvVars();
 // Export the path to 'opensphere' for application use.
 process.env.OPENSPHERE_PATH = getAppPath('opensphere', appEnv.basePath);
 
-// XHR response headers that should be discarded.
-const discardedHeaders = [
-  'content-security-policy',
-  'x-frame-options',
-  'x-xss-protection'
-];
-
 /**
  * Keep a global reference of the window object, if you don't, the window will
  * be closed automatically when the JavaScript object is garbage collected.
@@ -49,164 +39,14 @@ const discardedHeaders = [
 let mainWindow;
 
 /**
- * Get the absolute path for a preload script.
- * @param {string} script The script.
- * @return {string} The absolute path.
- */
-const getPreloadPath = (script) => {
-  return path.join(appEnv.preloadDir, script);
-};
-
-/**
- * Create a new browser window.
- * @param {WebPreferences} webPreferences The Electron web preferences.
- * @param {BrowserWindow} parentWindow The opening browser window.
- * @return {BrowserWindow}
- */
-const createBrowserWindow = (webPreferences, parentWindow) => {
-  // Create the browser window.
-  const parentBounds = parentWindow ? parentWindow.getBounds() : undefined;
-  const browserWindow = new BrowserWindow({
-    width: parentBounds ? parentBounds.width : 1600,
-    height: parentBounds ? parentBounds.height : 900,
-    x: parentBounds ? (parentBounds.x + 25) : undefined,
-    y: parentBounds ? (parentBounds.y + 25) : undefined,
-    webPreferences: webPreferences
-  });
-
-  // Load external preload scripts into the session.
-  if (fs.existsSync(appEnv.preloadDir)) {
-    const preloads = fs.readdirSync(appEnv.preloadDir);
-    browserWindow.webContents.session.setPreloads(preloads.map(getPreloadPath));
-  }
-
-  // Delete X-Frame-Options header from XHR responses to avoid preventing URL's from displaying in an iframe.
-  browserWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
-    const headers = Object.keys(details.responseHeaders);
-    headers.forEach((header) => {
-      if (discardedHeaders.includes(header.toLowerCase())) {
-        delete details.responseHeaders[header];
-      }
-    });
-
-    callback({cancel: false, responseHeaders: details.responseHeaders});
-  });
-
-  // Update history menu (forward/back state) on navigation.
-  browserWindow.webContents.on('did-navigate', (event) => {
-    appMenu.updateHistoryMenu();
-  });
-
-  // Update history menu (forward/back state) on page navigation (URL hash change).
-  browserWindow.webContents.on('did-navigate-in-page', (event) => {
-    appMenu.updateHistoryMenu();
-  });
-
-  browserWindow.webContents.on('new-window', (event, url, frameName) => {
-    log.debug(`Event [new-window]: ${url}`);
-
-    // Any path outside of the application should be opened in the system browser
-    // Reasons:
-    //   1. That's what the user expects
-    //   2. That's where all of their login sessions/cookies already are
-    //   3. We've purposely axed CORS and XSS security from Electron so that the
-    //      user isn't bothered by that nonsense in a desktop app. As soon as you
-    //      treat Electron as a generic browser, that tears a hole in everything.
-    const decodedUrl = decodeURIComponent(url);
-    if (decodedUrl.indexOf('about:blank') === -1 &&
-        !(decodedUrl.startsWith('file://') && decodedUrl.indexOf(slash(appEnv.basePath)) > -1)) {
-      event.preventDefault();
-      open(url);
-    } else if (url.indexOf('.html') == -1) {
-      // If the HTML file isn't specified in an internal URL, check if a matching app is configured.
-      const appName = getAppFromUrl(url);
-      if (appName) {
-        // Launch the matched app.
-        event.preventDefault();
-        createAppWindow(appName, url, browserWindow);
-      }
-    }
-  });
-
-  browserWindow.webContents.on('will-navigate', (event, url) => {
-    log.debug(`Event [will-navigate]: ${url}`);
-
-    // Internal navigation needs to detect when navigating to a configured app and get the correct URL for that app.
-    const decodedUrl = decodeURIComponent(url);
-    if (decodedUrl.startsWith('file://') && decodedUrl.indexOf(slash(appEnv.basePath)) > -1) {
-      const appName = getAppFromUrl(url);
-      if (appName) {
-        // Get the actual app URL, appended with any fragment/query string from the requested URL.
-        const appUrl = getAppUrl(appName, appEnv.basePath) + url.replace(/^[^#?]+/, '');
-        log.debug(`Loading app URL: ${appUrl}`);
-
-        event.preventDefault();
-        browserWindow.loadURL(appUrl);
-      }
-    }
-  });
-
-  browserWindow.webContents.on('will-prevent-unload', (event) => {
-    // The app is attempting to cancel the unload event. Prompt the user to allow this or not.
-    const choice = dialog.showMessageBoxSync(browserWindow, {
-      type: 'info',
-      buttons: ['Leave', 'Stay'],
-      icon: appEnv.iconPath || undefined,
-      title: 'Warning!',
-      message: 'You have unsaved changes on this page. If you navigate away from this page, your ' +
-          'changes will be lost.',
-      defaultId: 0,
-      cancelId: 1
-    });
-
-    if (choice === 0) {
-      event.preventDefault();
-    }
-  });
-
-  return browserWindow;
-};
-
-/**
- * Get a client certificate for the provided URL.
- * @param {string} url The URL.
- * @param {!Array<!Certificate>} list Available user certificates.
- * @param {function(Certificate)} callback The callback to call on certificate selection.
- * @param {WebContents} webContents The WebContents instance requesting a certificate.
- */
-const getClientCertificate = (url, list, callback, webContents) => {
-  getUserCertForUrl(url, list, webContents).then((cert) => {
-    callback(cert);
-  }, (err) => {
-    // This intentionally doesn't call the callback, because Electron will remember the decision. If the app was
-    // refreshed, we want Electron to try selecting a cert again when the app loads.
-    const reason = err && err.message || 'Unspecified reason.';
-    log.error(`Client certificate selection failed: ${reason}`);
-  });
-};
-
-/**
- * Open an application browser window.
- * @param {string} appName The app name.
- * @param {string} url The app URL.
- * @param {BrowserWindow} parentWindow The opening browser window.
- */
-const createAppWindow = (appName, url, parentWindow) => {
-  // Get the actual app URL, appended with any fragment/query string from the requested URL.
-  const appUrl = getAppUrl(appName, appEnv.basePath) + url.replace(/^[^#?]+/, '');
-
-  if (parentWindow && parentWindow.webContents) {
-    log.debug(`Launching app ${appName} with URL ${appUrl}`);
-
-    const appWindow = createBrowserWindow(parentWindow.webContents.getWebPreferences(), parentWindow);
-    appWindow.loadURL(appUrl);
-  }
-};
-
-/**
  * Create the main application window.
  */
 const createMainWindow = () => {
+  // Abort if there is already a main window reference.
+  if (mainWindow) {
+    return;
+  }
+
   // Default web preferences for the main browser window.
   const webPreferences = getDefaultWebPreferences();
 
@@ -221,23 +61,11 @@ const createMainWindow = () => {
   // Create the browser window.
   mainWindow = createBrowserWindow(webPreferences);
 
-  // Initialize auto update.
-  initAutoUpdate(mainWindow);
-
   // Load the app from the file system.
   const appUrl = getAppUrl(appEnv.baseApp, appEnv.basePath);
-  appMenu.setHomeUrl(appUrl);
 
-  log.info('loading', appUrl);
+  log.info(`Loading app: ${appUrl}`);
   mainWindow.loadURL(appUrl);
-
-  mainWindow.on('crashed', () => {
-    log.error('Main window crashed');
-  });
-
-  mainWindow.on('destroyed', () => {
-    log.error('Main window destroyed');
-  });
 
   // Emitted when the window is closed.
   mainWindow.on('closed', () => {
@@ -262,16 +90,8 @@ app.on('ready', () => {
   // Launch the application.
   createMainWindow();
 
-  if (!appEnv.isDev) {
-    // Allow opening Dev Tools via shortcut.
-    const shortcut = process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I';
-    globalShortcut.register(shortcut, () => {
-      const focusedWindow = BrowserWindow.getFocusedWindow();
-      if (focusedWindow) {
-        focusedWindow.toggleDevTools();
-      }
-    });
-  }
+  // Initialize auto update.
+  initAutoUpdate();
 });
 
 app.on('select-client-certificate', (event, webContents, url, list, callback) => {
@@ -293,12 +113,16 @@ app.on('window-all-closed', () => {
 app.on('activate', () => {
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
+  if (process.platform === 'darwin' && BrowserWindow.getAllWindows().length === 0) {
     createMainWindow();
   }
 });
 
 app.on('web-contents-created', (event, contents) => {
+  contents.on('crashed', (event, killed) => {
+    log.error('Web contents crashed!');
+  });
+
   contents.on('will-attach-webview', (event, webPreferences, params) => {
     // Strip away preload scripts because they always have Node integration enabled
     delete webPreferences.preload;

--- a/app/src/usercerts.js
+++ b/app/src/usercerts.js
@@ -1,4 +1,6 @@
 const Promise = require('bluebird');
+const log = require('electron-log');
+
 const {ipcMain} = require('electron');
 
 
@@ -7,6 +9,25 @@ const {ipcMain} = require('electron');
  * @type {Object<string, !Promise<!Electron.Certificate>>}
  */
 const promises = {};
+
+
+/**
+ * Get a client certificate for the provided URL.
+ * @param {string} url The URL.
+ * @param {!Array<!Certificate>} list Available user certificates.
+ * @param {function(Certificate)} callback The callback to call on certificate selection.
+ * @param {WebContents} webContents The WebContents instance requesting a certificate.
+ */
+const getClientCertificate = (url, list, callback, webContents) => {
+  getUserCertForUrl(url, list, webContents).then((cert) => {
+    callback(cert);
+  }, (err) => {
+    // This intentionally doesn't call the callback, because Electron will remember the decision. If the app was
+    // refreshed, we want Electron to try selecting a cert again when the app loads.
+    const reason = err && err.message || 'Unspecified reason.';
+    log.error(`Client certificate selection failed: ${reason}`);
+  });
+};
 
 
 /**
@@ -54,4 +75,4 @@ const getUserCertForUrl = (url, list, webContents) => {
 };
 
 
-module.exports = {getUserCertForUrl};
+module.exports = {getClientCertificate};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "npm run lint",
     "guide": "make -C docs clean html",
     "guide:auto": "sphinx-autobuild docs docs/_build/html",
-    "lint": "eslint app/src/**/*.js",
+    "lint": "eslint 'app/src/**/*.js'",
     "start": "electron .",
     "create-installers": "electron-builder -mwl --x64",
     "create-installer:linux": "electron-builder --linux --x64",
@@ -28,7 +28,6 @@
     "electron-is-dev": "^1.1.0",
     "electron-log": "^4.0.6",
     "electron-updater": "4.2.2",
-    "open": "^6.3.0",
     "slash": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**App Updates**

- Navigation to external links now uses the system default behavior (ie, in a browser).
- Auto update notifications will now use the focused window, or the first window if that's not available.
- Manual auto update will now notify the user if an update is not available.
- The History menu will now only display if `electron.apps` is configured. OpenSphere is a single-page application, so navigation is not particularly useful.

**Code Refactor**

- Moved browser window creation and general app navigation code from `main.js` to `appnav.js`.
- `appmenu.js` now creates menu configs ad-hoc instead of on module load.
- Removed the need to assign the main window and home URL externally for the menu.

**Build Updates**

- The `yarn lint` script will now process _all_ source files.
- Updated `.eslintrc` to use a Node environment and error on undefined variables.
- Replaced the `open` module with Electron's `shell.openExternal`.