### PR TITLE
feat(build): Add request dependecy, remove postbuild step

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "create-installers": "electron-builder -mwl --x64",
     "create-installer:linux": "electron-builder --linux --x64",
     "create-installer:mac": "electron-builder --mac --x64",
-    "create-installer:win": "electron-builder --win --x64",
-    "postinstall": "electron-builder install-app-deps"
+    "create-installer:win": "electron-builder --win --x64"
   },
   "repository": "https://github.com/ngageoint/opensphere-electron",
   "keywords": [
@@ -28,6 +27,7 @@
     "electron-is-dev": "^1.1.0",
     "electron-log": "^4.0.6",
     "electron-updater": "4.2.2",
+    "request": "^2.88.0",
     "slash": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
From my research, the postbuild step is not necessary and with the geopackage plugin it attempts to install canvas additional times