### PR TITLE
feat(request): allow overriding request headers from browser windows

### DIFF
--- a/app/src/appnav.js
+++ b/app/src/appnav.js
@@ -1,4 +1,5 @@
 // Node Modules
+const config = require('config');
 const fs = require('fs');
 const log = require('electron-log');
 const path = require('path');
@@ -63,6 +64,18 @@ const createBrowserWindow = (webPreferences, parentWindow) => {
   if (fs.existsSync(appEnv.preloadDir)) {
     const preloads = fs.readdirSync(appEnv.preloadDir);
     browserWindow.webContents.session.setPreloads(preloads.map(getPreloadPath));
+  }
+
+  if (config.has('electron.webRequest.requestHeaders')) {
+    // Request header overrides from config
+    const requestHeaders = config.get('electron.webRequest.requestHeaders');
+    browserWindow.webContents.session.webRequest.onBeforeSendHeaders((details, callback) => {
+      Object.assign(details.requestHeaders, requestHeaders);
+
+      callback({
+        requestHeaders: details.requestHeaders
+      });
+    });
   }
 
   // Delete X-Frame-Options header from XHR responses to avoid preventing URL's from displaying in an iframe.


### PR DESCRIPTION
This allows overriding headers for requests made from all browser windows in the Electron app. For example, to replace the origin add the following to the Electron app config:

```
{
  "electron": {
    "webRequest": {
      "requestHeaders": {
        "Origin": "https://myorigin.com"
      }
    }
  }
}
```