### PR TITLE
fix(cookies): reply to sender when an update request is made

### DIFF
--- a/app/src/cookies.js
+++ b/app/src/cookies.js
@@ -25,7 +25,7 @@ const EventType = {
 const updateRendererCookies = (webContents) => {
   session.defaultSession.cookies.get({url: cookieUrl}).then((cookies) => {
     const browserCookies = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
-    webContents.send(EventType.UPDATE, browserCookies);
+    webContents.reply(EventType.UPDATE, browserCookies);
   });
 };
 

--- a/app/src/cookies.js
+++ b/app/src/cookies.js
@@ -89,9 +89,7 @@ const onSetCookie = (event, value) => {
         secure: !!options.secure,
         sameSite: options.sameSite || 'lax'
       }).then(() => {
-        if (event.sender) {
-          onUpdateCookies(event);
-        }
+        onUpdateCookies(event);
       });
     }
   }


### PR DESCRIPTION
If something that isn't the main process requests a cookie update, `send` will only update main -- `reply` makes sure that whichever window made the request gets updated.