### PR TITLE
feat(update): support authenticating to the auto update release url

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -101,7 +101,7 @@ app.on('ready', () => {
   createMainWindow();
 
   // Initialize auto update.
-  initAutoUpdate();
+  initAutoUpdate(mainWindow);
 });
 
 app.on('select-client-certificate', (event, webContents, url, list, callback) => {


### PR DESCRIPTION
Electron's `ClientRequest` API does not support selecting/passing certificates to the request URL. This API is used by `electron-updater`, which prevents checking for updates if the release URL requires authentication. To work around this, we can copy cookies for the release URL from the main window (OpenSphere) to the session used by `electron-updater` to check for updates. This depends on the main window making a request to the release URL first, which will be authenticated and set cookies appropriately. This change has been made in ngageoint/opensphere/pull/1149.