### PR TITLE
Support user settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,9 @@ module.exports = {
     "es6": true,
     "node": true
   },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
   "rules": {
     // Don't dangle commas.
     "comma-dangle": ["error", "never"],

--- a/app/src/appsettings.js
+++ b/app/src/appsettings.js
@@ -1,0 +1,242 @@
+const Promise = require('bluebird');
+const {app, ipcMain} = require('electron');
+const log = require('electron-log');
+const fs = Promise.promisifyAll(require('fs'));
+const path = require('path');
+
+const appEnv = require('./appenv.js');
+const {getAppPath} = require('./apppath.js');
+
+
+/**
+ * Settings event types.
+ * @enum {string}
+ */
+const EventType = {
+  ADD: 'add-settings',
+  GET_FILES: 'get-settings-files',
+  GET_BASE_FILE: 'get-base-settings-file',
+  GET_USER_DIR: 'get-user-settings-dir',
+  SET: 'set-settings'
+};
+
+
+/**
+ * The directory containing user config files and copied app settings.
+ * @type {string}
+ */
+let userSettingsDir = '';
+
+
+/**
+ * The copied base settings file that will be loaded by the application.
+ * @type {string}
+ */
+let baseSettingsFile = '';
+
+
+/**
+ * Settings files available to the application.
+ * @type {!Array<string>}
+ */
+let settingsFiles = [];
+
+
+/**
+ * Get the path to the base settings file loaded by the application.
+ * @return {string}
+ */
+const getBaseSettingsFile = () => baseSettingsFile;
+
+
+/**
+ * Get the settings files available to the application.
+ * @return {!Array<string>}
+ */
+const getSettingsFiles = () => settingsFiles;
+
+
+/**
+ * Get directory containing user config files and copied app settings.
+ * @return {!string}
+ */
+const getUserSettingsDir = () => userSettingsDir;
+
+
+/**
+ * Write the base application settings file as a list of overrides.
+ * @return {!Promise} A promise that resolves when the file has been saved.
+ */
+const saveBaseSettings = async () => {
+  if (baseSettingsFile) {
+    const overridesSettings = {
+      overrides: settingsFiles
+    };
+
+    log.debug(`Writing app settings to: ${baseSettingsFile}`);
+    await fs.writeFileAsync(baseSettingsFile, JSON.stringify(overridesSettings, null, 2));
+  } else {
+    return Promise.reject(new Error('App settings path has not been initialized!'));
+  }
+};
+
+
+/**
+ * Initialize settings for the base application.
+ * @return {!Promise} A promise that resolves when settings have been initialized.
+ */
+const initAppSettings = async () => {
+  //
+  // Resolve the base path for settings files.
+  //  - The debug app uses <app>/.build.
+  //  - The compiled app uses <app>/dist/<app>/config.
+  //  - The built Electron app uses <app>/config within the resources directory.
+  //
+  const appPath = getAppPath(appEnv.baseApp, appEnv.basePath);
+
+  let appSettingsDir = '';
+  if (appEnv.isDebug) {
+    // In the local debug build, copy settings files to .build/userConfig.
+    appSettingsDir = path.join(appPath, '.build');
+    userSettingsDir = path.join(appSettingsDir, 'userConfig');
+  } else if (appEnv.isDev) {
+    // In the local compiled build, copy settings files to <app>/dist/<app>/userConfig.
+    appSettingsDir = path.join(appPath, 'config');
+    userSettingsDir = path.join(appSettingsDir, '..', 'userConfig');
+  } else {
+    // In the production build, copy settings files to the userData directory (varies by OS).
+    // See: https://www.electronjs.org/docs/api/app#appgetpathname
+    appSettingsDir = path.join(appPath, 'config');
+    userSettingsDir = path.join(app.getPath('userData'), 'config');
+  }
+
+  // Create the path for the base settings file loaded by the application.
+  baseSettingsFile = path.join(userSettingsDir, 'settings.json');
+
+  if (!fs.existsSync(userSettingsDir)) {
+    // Create the user settings directory that the app will use to load/store settings files.
+    await fs.mkdirAsync(userSettingsDir);
+  } else if (fs.existsSync(baseSettingsFile)) {
+    // Base settings file already exists, so load in the list of settings files from the overrides.
+    const baseSettings = await fs.readFileAsync(baseSettingsFile);
+    if (baseSettings) {
+      const baseSettingsJson = JSON.parse(baseSettings);
+      settingsFiles = baseSettingsJson.overrides || [];
+    }
+  }
+
+  const appSettingsFile = path.join(appSettingsDir, appEnv.isDebug ? 'settings-debug.json' : 'settings.json');
+  if (fs.existsSync(appSettingsFile)) {
+    // Copy the original app settings into the user directory.
+    const defaultSettingsFile = path.join(userSettingsDir, 'settings-default.json');
+    await fs.copyFileAsync(appSettingsFile, defaultSettingsFile);
+
+    // If the list of overrides was not loaded from disk, initialize it with the default settings and save the file.
+    if (!settingsFiles.length) {
+      settingsFiles.push(defaultSettingsFile);
+    }
+  } else {
+    log.warn(`Unable to locate app settings file at ${appSettingsFile}!`);
+  }
+
+  // Make sure the base settings file is saved.
+  await saveBaseSettings();
+};
+
+
+/**
+ * Initialize cookie event handlers.
+ */
+const initHandlers = () => {
+  ipcMain.handle(EventType.ADD, onAddSettings);
+  ipcMain.handle(EventType.GET_FILES, onGetSettingsFiles);
+  ipcMain.handle(EventType.GET_BASE_FILE, onGetBaseSettingsFile);
+  ipcMain.handle(EventType.GET_USER_DIR, onGetUserSettingsDir);
+  ipcMain.handle(EventType.SET, onSetSettings);
+};
+
+
+/**
+ * Dispose cookie event handlers.
+ */
+const disposeHandlers = () => {
+  ipcMain.removeListener(EventType.ADD, onAddSettings);
+  ipcMain.removeListener(EventType.GET_FILES, onGetSettingsFiles);
+  ipcMain.removeListener(EventType.GET_BASE_FILE, onGetBaseSettingsFile);
+  ipcMain.removeListener(EventType.GET_USER_DIR, onGetUserSettingsDir);
+  ipcMain.removeListener(EventType.SET, onSetSettings);
+};
+
+
+/**
+ * Save a new settings file.
+ * @param {Event} event The event to reply to.
+ * @param {string} fileName The settings file name.
+ * @param {string} content The settings content.
+ * @return {!Promise<!Array<string>>} A promise that resolves to the updated list of settings files.
+ */
+const onAddSettings = async (event, fileName, content) => {
+  const filePath = path.join(userSettingsDir, fileName);
+  await fs.writeFileAsync(filePath, content);
+
+  if (settingsFiles.indexOf(filePath) === -1) {
+    settingsFiles.push(filePath);
+  }
+
+  return settingsFiles;
+};
+
+
+/**
+ * Handle request for the base settings file.
+ * @param {Event} event The event.
+ */
+const onGetBaseSettingsFile = async (event) => baseSettingsFile;
+
+
+/**
+ * Handle request for the settings files.
+ * @param {Event} event The event.
+ */
+const onGetSettingsFiles = async (event) => settingsFiles;
+
+
+/**
+ * Handle request for the user settings directory.
+ * @param {Event} event The event.
+ */
+const onGetUserSettingsDir = async (event) => userSettingsDir;
+
+
+/**
+ * Handle settings set event from renderer.
+ * @param {Event} event The event.
+ * @param {!Array<string>} value The settings file value.
+ */
+const onSetSettings = async (event, value) => {
+  await setSettingsFiles(value);
+  return value;
+};
+
+
+/**
+ * Set the settings files available to the application.
+ * @param {!Array<string>} value The settings files.
+ * @return {!Promise} A promise that resolves when settings files have been updated and saved.
+ */
+const setSettingsFiles = async (value) => {
+  settingsFiles = value;
+  await saveBaseSettings();
+  return settingsFiles;
+};
+
+
+module.exports = {
+  disposeHandlers,
+  getBaseSettingsFile,
+  getSettingsFiles,
+  getUserSettingsDir,
+  initAppSettings,
+  initHandlers,
+  setSettingsFiles
+};

--- a/app/src/appsettings.js
+++ b/app/src/appsettings.js
@@ -18,7 +18,8 @@ const EventType = {
   GET_BASE_FILE: 'get-base-settings-file',
   GET_USER_DIR: 'get-user-settings-dir',
   REMOVE: 'remove-settings',
-  SET: 'set-settings'
+  SET: 'set-settings',
+  UPDATE: 'update-settings'
 };
 
 
@@ -216,6 +217,7 @@ const initHandlers = () => {
   ipcMain.handle(EventType.GET_USER_DIR, onGetUserSettingsDir);
   ipcMain.handle(EventType.REMOVE, onRemoveSettings);
   ipcMain.handle(EventType.SET, onSetSettings);
+  ipcMain.handle(EventType.UPDATE, onUpdateSettings);
 };
 
 
@@ -229,6 +231,7 @@ const disposeHandlers = () => {
   ipcMain.removeListener(EventType.GET_USER_DIR, onGetUserSettingsDir);
   ipcMain.removeListener(EventType.REMOVE, onRemoveSettings);
   ipcMain.removeListener(EventType.SET, onSetSettings);
+  ipcMain.removeListener(EventType.UPDATE, onUpdateSettings);
 };
 
 
@@ -256,7 +259,7 @@ const onAddSettings = async (event, file, content) => {
 /**
  * Remove a settings file.
  * @param {Event} event The event to reply to.
- * @param {!ElectronOS.SettingsFile} file The settings file path.
+ * @param {!ElectronOS.SettingsFile} file The settings.
  * @return {!Promise<!Array<!ElectronOS.SettingsFile>>} A promise that resolves to the updated list of settings files.
  */
 const onRemoveSettings = async (event, file) => {
@@ -270,6 +273,26 @@ const onRemoveSettings = async (event, file) => {
       } catch (e) {
         log.error(`Failed deleting config file at ${file.path}: ${e.message}`);
       }
+    }
+  }
+
+  await saveSettings();
+
+  return settingsFiles;
+};
+
+
+/**
+ * Update a settings file.
+ * @param {Event} event The event to reply to.
+ * @param {!ElectronOS.SettingsFile} file The settings.
+ * @return {!Promise<!Array<!ElectronOS.SettingsFile>>} A promise that resolves to the updated list of settings files.
+ */
+const onUpdateSettings = async (event, file) => {
+  if (file) {
+    const idx = settingsFiles.findIndex((f) => f.path === file.path);
+    if (idx > -1) {
+      settingsFiles[idx] = file;
     }
   }
 

--- a/app/src/appsettings.js
+++ b/app/src/appsettings.js
@@ -142,10 +142,10 @@ const initPaths = () => {
   }
 
   // Base settings file that will be loaded by the application.
-  baseSettingsFile = path.join(userSettingsDir, 'settings.json');
+  baseSettingsFile = path.join(userSettingsDir, '.settings.json');
 
   // Original settings copied from the application.
-  defaultSettingsFile = path.join(userSettingsDir, 'settings-default.json');
+  defaultSettingsFile = path.join(userSettingsDir, '.settings-default.json');
 
   // Config file for settings loaded in the application.
   settingsConfigPath = path.join(userSettingsDir, '.settings-files.json');
@@ -246,8 +246,13 @@ const onAddSettings = async (event, file, content) => {
   file.path = path.join(userSettingsDir, file.path);
   await fs.writeFileAsync(file.path, content);
 
-  if (!settingsFiles.some((f) => f.path === file.path)) {
+  const idx = settingsFiles.findIndex((f) => f.path === file.path);
+  if (idx === -1) {
+    // New file
     settingsFiles.push(file);
+  } else {
+    // Replace existing file
+    settingsFiles[idx] = file;
   }
 
   await saveSettings();

--- a/app/src/appsettings.js
+++ b/app/src/appsettings.js
@@ -7,22 +7,7 @@ const path = require('path');
 
 const appEnv = require('./appenv.js');
 const {getAppPath} = require('./apppath.js');
-
-
-/**
- * Settings event types.
- * @enum {string}
- */
-const EventType = {
-  ADD: 'add-settings',
-  GET_FILES: 'get-settings-files',
-  GET_BASE_FILE: 'get-base-settings-file',
-  GET_USER_DIR: 'get-user-settings-dir',
-  REMOVE: 'remove-settings',
-  SET: 'set-settings',
-  SUPPORTED: 'user-settings-supported',
-  UPDATE: 'update-settings'
-};
+const SettingsEventType = require('./settingseventtype.js');
 
 
 /**
@@ -237,13 +222,13 @@ const initAppSettings = async () => {
  * Initialize cookie event handlers.
  */
 const initHandlers = () => {
-  ipcMain.handle(EventType.ADD, onAddSettings);
-  ipcMain.handle(EventType.GET_FILES, onGetSettingsFiles);
-  ipcMain.handle(EventType.GET_BASE_FILE, onGetBaseSettingsFile);
-  ipcMain.handle(EventType.GET_USER_DIR, onGetUserSettingsDir);
-  ipcMain.handle(EventType.REMOVE, onRemoveSettings);
-  ipcMain.handle(EventType.SET, onSetSettings);
-  ipcMain.handle(EventType.UPDATE, onUpdateSettings);
+  ipcMain.handle(SettingsEventType.ADD, onAddSettings);
+  ipcMain.handle(SettingsEventType.GET_FILES, onGetSettingsFiles);
+  ipcMain.handle(SettingsEventType.GET_BASE_FILE, onGetBaseSettingsFile);
+  ipcMain.handle(SettingsEventType.GET_USER_DIR, onGetUserSettingsDir);
+  ipcMain.handle(SettingsEventType.REMOVE, onRemoveSettings);
+  ipcMain.handle(SettingsEventType.SET, onSetSettings);
+  ipcMain.handle(SettingsEventType.UPDATE, onUpdateSettings);
 };
 
 
@@ -251,13 +236,13 @@ const initHandlers = () => {
  * Dispose cookie event handlers.
  */
 const disposeHandlers = () => {
-  ipcMain.removeListener(EventType.ADD, onAddSettings);
-  ipcMain.removeListener(EventType.GET_FILES, onGetSettingsFiles);
-  ipcMain.removeListener(EventType.GET_BASE_FILE, onGetBaseSettingsFile);
-  ipcMain.removeListener(EventType.GET_USER_DIR, onGetUserSettingsDir);
-  ipcMain.removeListener(EventType.REMOVE, onRemoveSettings);
-  ipcMain.removeListener(EventType.SET, onSetSettings);
-  ipcMain.removeListener(EventType.UPDATE, onUpdateSettings);
+  ipcMain.removeListener(SettingsEventType.ADD, onAddSettings);
+  ipcMain.removeListener(SettingsEventType.GET_FILES, onGetSettingsFiles);
+  ipcMain.removeListener(SettingsEventType.GET_BASE_FILE, onGetBaseSettingsFile);
+  ipcMain.removeListener(SettingsEventType.GET_USER_DIR, onGetUserSettingsDir);
+  ipcMain.removeListener(SettingsEventType.REMOVE, onRemoveSettings);
+  ipcMain.removeListener(SettingsEventType.SET, onSetSettings);
+  ipcMain.removeListener(SettingsEventType.UPDATE, onUpdateSettings);
 };
 
 
@@ -399,7 +384,7 @@ const supportsUserSettings = () => {
 
 
 // Allow the renderer to check if user settings are supported.
-ipcMain.handle(EventType.SUPPORTED, onSupportsUserSettings);
+ipcMain.handle(SettingsEventType.SUPPORTED, onSupportsUserSettings);
 
 
 module.exports = {

--- a/app/src/appsettings.js
+++ b/app/src/appsettings.js
@@ -89,16 +89,16 @@ const getUserSettingsDir = () => userSettingsDir;
 
 
 /**
- * Map settings file to the override path.
+ * Reduce settings files to enabled overrides.
+ * @param {!Array<string>} overrides The enabled overrides.
  * @param {!ElectronOS.SettingsFile} file The file.
- * @return {string} The override path.
+ * @return {!Array<string>} The enabled overrides.
  */
-const mapFileToOverride = (file) => {
-  let {path} = file;
-  if (!file.enabled) {
-    path = `!${path}`;
+const reduceFilesToOverrides = (overrides, file) => {
+  if (file.enabled) {
+    overrides.push(file.path);
   }
-  return path;
+  return overrides;
 };
 
 
@@ -108,7 +108,7 @@ const mapFileToOverride = (file) => {
  */
 const saveSettings = async () => {
   if (baseSettingsFile) {
-    const overrides = settingsFiles.map(mapFileToOverride);
+    const overrides = settingsFiles.reduce(reduceFilesToOverrides, []);
     await fs.writeFileAsync(baseSettingsFile, JSON.stringify({overrides}, null, 2));
   } else {
     return new Error('App settings path has not been initialized!');

--- a/app/src/appsettings.js
+++ b/app/src/appsettings.js
@@ -264,6 +264,12 @@ const onRemoveSettings = async (event, file) => {
     const idx = settingsFiles.findIndex((f) => f.path === file.path);
     if (idx > -1) {
       settingsFiles.splice(idx, 1);
+
+      try {
+        await fs.unlinkAsync(file.path);
+      } catch (e) {
+        log.error(`Failed deleting config file at ${file.path}: ${e.message}`);
+      }
     }
   }
 

--- a/app/src/appsettings.js
+++ b/app/src/appsettings.js
@@ -4,6 +4,7 @@ const {app, ipcMain} = require('electron');
 const log = require('electron-log');
 const fs = Promise.promisifyAll(require('fs'));
 const path = require('path');
+const url = require('url');
 
 const appEnv = require('./appenv.js');
 const {getAppPath} = require('./apppath.js');
@@ -99,7 +100,8 @@ const reduceFilesToOverrides = (overrides, file) => {
         overrides.push(`${file.path}?${cd}`);
       }
     } else {
-      overrides.push(file.path);
+      // Local file, convert the path to a file:// URL.
+      overrides.push(url.pathToFileURL(file.path).toString());
     }
   }
   return overrides;

--- a/app/src/cookieeventtype.js
+++ b/app/src/cookieeventtype.js
@@ -1,0 +1,8 @@
+/**
+ * Cookie event types.
+ * @enum {string}
+ */
+module.exports = {
+  SET: 'set-cookie',
+  UPDATE: 'update-cookies'
+};

--- a/app/src/cookies.js
+++ b/app/src/cookies.js
@@ -1,21 +1,13 @@
 const {ipcMain, session} = require('electron');
 
+const CookieEventType = require('./cookieeventtype.js');
+
 
 /**
  * URL used for storing session cookies.
  * @type {string}
  */
 const cookieUrl = 'https://github.com/ngageoint/opensphere-electron';
-
-
-/**
- * Cookie event types.
- * @enum {string}
- */
-const EventType = {
-  SET: 'set-cookie',
-  UPDATE: 'update-cookies'
-};
 
 
 /**
@@ -103,7 +95,7 @@ const onSetCookie = (event, value) => {
 const onUpdateCookies = (event) => {
   session.defaultSession.cookies.get({url: cookieUrl}).then((cookies) => {
     const browserCookies = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
-    event.reply(EventType.UPDATE, browserCookies);
+    event.reply(CookieEventType.UPDATE, browserCookies);
   });
 };
 
@@ -112,8 +104,8 @@ const onUpdateCookies = (event) => {
  * Initialize cookie event handlers.
  */
 const initHandlers = () => {
-  ipcMain.on(EventType.SET, onSetCookie);
-  ipcMain.on(EventType.UPDATE, onUpdateCookies);
+  ipcMain.on(CookieEventType.SET, onSetCookie);
+  ipcMain.on(CookieEventType.UPDATE, onUpdateCookies);
 };
 
 
@@ -121,8 +113,8 @@ const initHandlers = () => {
  * Dispose cookie event handlers.
  */
 const disposeHandlers = () => {
-  ipcMain.removeListener(EventType.SET, onSetCookie);
-  ipcMain.removeListener(EventType.UPDATE, onUpdateCookies);
+  ipcMain.removeListener(CookieEventType.SET, onSetCookie);
+  ipcMain.removeListener(CookieEventType.UPDATE, onUpdateCookies);
 };
 
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -13,6 +13,7 @@ const appEnv = require('./appenv.js');
 const appMenu = require('./appmenu.js');
 const {createBrowserWindow} = require('./appnav.js');
 const {getAppPath, getAppUrl} = require('./apppath.js');
+const settings = require('./appsettings.js');
 const {disposeAutoUpdate, initAutoUpdate} = require('./autoupdate.js');
 const cookies = require('./cookies.js');
 const {getClientCertificate} = require('./usercerts.js');
@@ -110,11 +111,17 @@ app.on('ready', () => {
   // Set up cookie IPC handlers.
   cookies.initHandlers();
 
-  // Launch the application.
-  createMainWindow();
+  // Set up settings IPC handlers.
+  settings.initHandlers();
 
-  // Initialize auto update.
-  initAutoUpdate(mainWindow);
+  // Initialize settings files for the application.
+  settings.initAppSettings().then(() => {
+    // Launch the application.
+    createMainWindow();
+
+    // Initialize auto update.
+    initAutoUpdate(mainWindow);
+  });
 });
 
 app.on('select-client-certificate', (event, webContents, url, list, callback) => {

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -13,7 +13,7 @@ const appEnv = require('./appenv.js');
 const appMenu = require('./appmenu.js');
 const {createBrowserWindow} = require('./appnav.js');
 const {getAppPath, getAppUrl} = require('./apppath.js');
-const settings = require('./appsettings.js');
+const {initAppSettings} = require('./appsettings.js');
 const {disposeAutoUpdate, initAutoUpdate} = require('./autoupdate.js');
 const cookies = require('./cookies.js');
 const {getClientCertificate} = require('./usercerts.js');
@@ -111,11 +111,8 @@ app.on('ready', () => {
   // Set up cookie IPC handlers.
   cookies.initHandlers();
 
-  // Set up settings IPC handlers.
-  settings.initHandlers();
-
   // Initialize settings files for the application.
-  settings.initAppSettings().then(() => {
+  initAppSettings().then(() => {
     // Launch the application.
     createMainWindow();
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -171,6 +171,11 @@ app.on('web-contents-created', (event, contents) => {
   });
 });
 
+// Allow the renderer to determine if it's the main Electron window.
+ipcMain.handle('is-main-window', async (event) => {
+  return !!mainWindow && event.sender === mainWindow.webContents;
+});
+
 ipcMain.on('restart', (event, value) => {
   relaunch();
 });

--- a/app/src/settingseventtype.js
+++ b/app/src/settingseventtype.js
@@ -1,0 +1,14 @@
+/**
+ * Settings event types.
+ * @enum {string}
+ */
+module.exports = {
+  ADD: 'add-settings',
+  GET_FILES: 'get-settings-files',
+  GET_BASE_FILE: 'get-base-settings-file',
+  GET_USER_DIR: 'get-user-settings-dir',
+  REMOVE: 'remove-settings',
+  SET: 'set-settings',
+  SUPPORTED: 'user-settings-supported',
+  UPDATE: 'update-settings'
+};

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
   "electron": {
     "appName": "OpenSphere",
+    "enableUserSettings": true,
     "releaseUrl": "https://github.com/ngageoint/opensphere-electron/releases"
   }
 }


### PR DESCRIPTION
This adds support for managing user settings files, as well as the default application settings file. The [opensphere PR](https://github.com/ngageoint/opensphere/pull/1299) adds a UI to interact with these new APIs.

- Updated the eslint ECMA version to 2020 to allow language features like async/await. These are supported by the Chromium version used by Electron 8.5.5 (our current version).
- Added an `appsettings` module to manage settings files an interact with the renderer process over IPC. User-driven settings are enabled by default, but may be disabled by setting `electron.enableUserSettings` to `false` (or omitting the setting) in the Electron config. Apps providing their own Electron config must add this setting if they wish to use this feature.
- Added an API for the renderer process to determine if it's the main browser window.